### PR TITLE
fix(security): tighten rules, dedupe auth errors, derive payment redirects

### DIFF
--- a/apps/creator-dashboard/src/screens/LoginScreen.jsx
+++ b/apps/creator-dashboard/src/screens/LoginScreen.jsx
@@ -143,9 +143,9 @@ const LoginScreen = () => {
     } catch (error) {
       setIsLoading(false);
       switch (error.code) {
+        // Single generic outcome for all credential failures — prevents
+        // email enumeration via the login form.
         case 'auth/user-not-found':
-          setEmailError('No hay cuenta con este correo');
-          break;
         case 'auth/wrong-password':
         case 'auth/invalid-credential':
           setPasswordError('Email o contraseña incorrectos.');
@@ -199,8 +199,17 @@ const LoginScreen = () => {
       setShowForgotPassword(false);
       setFormError(null);
     } catch (error) {
-      logger.error('[LoginScreen] Password Reset Error:', error);
-      setFormError('No pudimos enviar el correo. Intenta de nuevo');
+      // Show the same "sent" UI even when the email isn't registered, so the
+      // reset endpoint can't be used to enumerate accounts. Other failures
+      // surface a generic error.
+      if (error?.code === 'auth/user-not-found') {
+        setForgotSent(true);
+        setShowForgotPassword(false);
+        setFormError(null);
+      } else {
+        logger.error('[LoginScreen] Password Reset Error:', error);
+        setFormError('No pudimos enviar el correo. Intenta de nuevo');
+      }
     } finally {
       setIsLoading(false);
     }

--- a/apps/pwa/src/screens/LoginScreen.js
+++ b/apps/pwa/src/screens/LoginScreen.js
@@ -156,17 +156,14 @@ const LoginScreen = ({ navigation }) => {
 
       if (code) {
         switch (code) {
+          // Generic message for all credential-mismatch outcomes prevents
+          // email enumeration via the login form (user-not-found vs
+          // wrong-password disclosed account existence).
           case 'auth/user-not-found':
-            errorMessage = 'No hay ninguna cuenta con este correo. Crea una cuenta o revisa el correo.';
-            setEmailError(errorMessage);
-            break;
           case 'auth/wrong-password':
-            errorMessage = 'Contraseña incorrecta. Revisa tu contraseña o usa "¿Olvidaste tu contraseña?".';
-            setPasswordError('Contraseña incorrecta');
-            setShowForgotPassword(true);
-            break;
           case 'auth/invalid-credential':
-            errorMessage = 'Correo o contraseña incorrectos. Revisa los datos o crea una cuenta si no tienes una.';
+            errorMessage = 'Correo o contraseña incorrectos.';
+            setPasswordError('Correo o contraseña incorrectos');
             setShowForgotPassword(true);
             break;
           case 'auth/invalid-email':
@@ -314,22 +311,28 @@ const LoginScreen = ({ navigation }) => {
       return;
     }
 
+    // Show the same success message regardless of whether the email exists,
+    // so the password-reset endpoint can't be used to enumerate accounts.
+    // auth/user-not-found is silently treated as success.
+    const genericResetSuccess = 'Si existe una cuenta con ese correo, te enviaremos un enlace para restablecer tu contraseña. Revisa tu bandeja (y spam).';
     try {
       await authService.resetPassword(email);
       setAuthError(null);
-      Alert.alert('Éxito', 'Revisa tu correo (spam). Puede estar en la carpeta de spam.');
+      Alert.alert('Listo', genericResetSuccess);
     } catch (error) {
-      logger.error('Password Reset Error:', error);
       const code = error?.code;
-      let msg = 'No pudimos enviar el correo de recuperación. Intenta de nuevo.';
       if (code === 'auth/user-not-found') {
-        msg = 'No hay ninguna cuenta con este correo. Revisa el correo o crea una cuenta.';
-      } else if (code === 'auth/invalid-email') {
+        // Don't disclose existence — show the same success state.
+        setAuthError(null);
+        Alert.alert('Listo', genericResetSuccess);
+        return;
+      }
+      logger.error('Password Reset Error:', error);
+      let msg = 'No pudimos enviar el correo de recuperación. Intenta de nuevo.';
+      if (code === 'auth/invalid-email') {
         msg = 'Correo electrónico no válido.';
       } else if (code === 'auth/too-many-requests') {
         msg = 'Demasiados intentos. Espera un momento e intenta de nuevo.';
-      } else if (error?.message) {
-        msg = error.message;
       }
       setAuthError(msg);
     }

--- a/apps/pwa/src/screens/NutritionScreen.web.jsx
+++ b/apps/pwa/src/screens/NutritionScreen.web.jsx
@@ -5258,7 +5258,7 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(255,255,255,0.15)',
     backgroundColor: 'rgba(255,255,255,0.06)',
     color: '#fff',
-    fontSize: 15,
+    fontSize: 16,
   },
   misComidasPlusBtn: {
     width: 44,
@@ -5789,7 +5789,7 @@ const styles = StyleSheet.create({
     borderColor: 'rgba(255,255,255,0.15)',
     backgroundColor: 'rgba(255,255,255,0.06)',
     color: '#fff',
-    fontSize: 15,
+    fontSize: 16,
   },
   buscarFilterToggle: {
     width: 44,

--- a/config/firebase/firestore.rules
+++ b/config/firebase/firestore.rules
@@ -51,6 +51,9 @@ service cloud.firestore {
       // subscriptions, email, email_verified, trial_used, purchased_courses,
       // username, created_at, cards — are Admin-SDK-only (the API mutates
       // them server-side, bypassing rules). Admin retains full update access.
+      // Length caps on user-controlled string fields prevent a single self-
+      // update from bloating the user doc toward Firestore's 1MiB limit
+      // (the doc is read on every login).
       allow update: if (isOwner(userId) &&
         request.resource.data.diff(resource.data).affectedKeys().hasOnly([
           'displayName', 'photoURL', 'profilePictureUrl',
@@ -68,7 +71,15 @@ service cloud.firestore {
           'creatorNavPreferences', 'socialLinks', 'websiteUrl',
           'howTheyFoundUs',
           'lastSessionDate', 'updated_at'
-        ])) || isAdmin();
+        ]) &&
+        request.resource.data.get('displayName', '').size() < 100 &&
+        request.resource.data.get('bio', '').size() < 1000 &&
+        request.resource.data.get('websiteUrl', '').size() < 500 &&
+        request.resource.data.get('howTheyFoundUs', '').size() < 1000 &&
+        request.resource.data.get('city', '').size() < 100 &&
+        request.resource.data.get('country', '').size() < 100 &&
+        request.resource.data.get('phoneNumber', '').size() < 50
+      ) || isAdmin();
       allow delete: if isOwner(userId) || isAdmin();
       
       // Exercise history subcollections
@@ -508,10 +519,17 @@ service cloud.firestore {
       // `allow create: if true` allowed unauthenticated public writes with no
       // schema constraints — anyone could spam arbitrary docs into any event's
       // waitlist subcollection.
-      allow create: if isSignedIn() && (
-        request.resource.data.get('userId', '') == request.auth.uid
-        || waitId == request.auth.uid
-      );
+      // Field allowlist mirrors registrations to prevent doc-shape bloat.
+      allow create: if isSignedIn()
+        && (
+          request.resource.data.get('userId', '') == request.auth.uid
+          || waitId == request.auth.uid
+        )
+        && request.resource.data.keys().hasOnly([
+          'userId', 'email', 'nombre', 'displayName', 'phoneNumber',
+          'responses', 'fieldValues', 'created_at', 'createdAt',
+          'source'
+        ]);
       // Creator and admin can read all waitlist entries; waitlist user can read their own
       allow read: if isSignedIn() && (
         get(/databases/$(database)/documents/events/$(eventId)).data.creator_id == request.auth.uid
@@ -775,11 +793,16 @@ service cloud.firestore {
       // Cross-creator courseIds in the bundle are still server-side enforced
       // by F-NEW-07 / F-SVC-01 in bundleAssignment.ts; the rule layer caps
       // the worst-case (publishing a bundle attributed to someone else).
+      // Once published, a creator cannot revert to draft — prevents the
+      // publish/unpublish cycle that would let pricing change after a buyer
+      // sees the published listing. (No admin override exists at the rule
+      // layer; admin SDK bypasses rules and can force a transition if needed.)
       allow update: if isSignedIn()
         && request.auth.uid == resource.data.creatorId
         && request.resource.data.creatorId == resource.data.creatorId
         && (request.resource.data.status == 'draft' ||
-            request.resource.data.status == 'published');
+            request.resource.data.status == 'published')
+        && !(resource.data.status == 'published' && request.resource.data.status == 'draft');
       allow delete: if false;
     }
 

--- a/config/firebase/storage.rules
+++ b/config/firebase/storage.rules
@@ -2,15 +2,17 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
     // Profile pictures (Tier 5.2 lockdown)
-    // Read: owner, any user looking at a creator/admin's photo, or an admin
-    // looking at any user. Wake isn't a social product; non-creator photos
-    // are private.
+    // Read: owner or admin only. The previous role-based read branch
+    // (allow if target user has role creator/admin) let an attacker enumerate
+    // the creator/admin roster by probing UIDs — read-success vs permission-
+    // denied was a side-channel. Legitimate display of creator photos in
+    // client surfaces uses Firebase Storage download tokens (getDownloadURL),
+    // which bypass rules, so this tightening doesn't break tokened access.
     // Write enforcement is at the API layer via signed URLs.
     match /profiles/{userId}/{fileName} {
       allow read: if request.auth != null
         && (
           request.auth.uid == userId
-          || firestore.get(/databases/(default)/documents/users/$(userId)).data.role in ['creator', 'admin']
           || firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.role == 'admin'
         );
 
@@ -26,7 +28,6 @@ service firebase.storage {
       allow read: if request.auth != null
         && (
           request.auth.uid == userId
-          || firestore.get(/databases/(default)/documents/users/$(userId)).data.role in ['creator', 'admin']
           || firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.role == 'admin'
         );
 
@@ -90,27 +91,29 @@ service firebase.storage {
     match /cards/{userId}/{fileName} {
       // Allow authenticated users to read cards
       allow read: if request.auth != null;
-      
+
       // Allow users to write only their own cards
-      allow write: if request.auth != null 
+      allow write: if request.auth != null
         && request.auth.uid == userId
         && (
           (request.resource.contentType.matches('image/.*') && request.resource.size < 10 * 1024 * 1024)  // Max 10MB for images
           ||
-          (request.resource.contentType.matches('video/.*'))  // No size limit for videos
+          (request.resource.contentType.matches('video/.*') && request.resource.size < 500 * 1024 * 1024)  // Max 500MB for videos
         );
     }
     
     // Creator media library (personal folder: images/videos for reuse across programs/sessions)
-    // Public read: these URLs are embedded in program/session data viewed by clients via <img> tags
+    // Read requires auth — embedded <img> tags use download tokens which bypass
+    // rules, so authed access doesn't break legitimate program/session display.
+    // Untokened path probing (the enumeration vector) is now blocked.
     match /creator_media/{creatorId}/{fileName} {
-      allow read: if true;
+      allow read: if request.auth != null;
       allow write: if request.auth != null
         && request.auth.uid == creatorId
         && (
           (request.resource.contentType.matches('image/.*') && request.resource.size < 10 * 1024 * 1024)
           ||
-          request.resource.contentType.matches('video/.*')
+          (request.resource.contentType.matches('video/.*') && request.resource.size < 500 * 1024 * 1024)
         );
     }
 

--- a/functions/src/api/app.ts
+++ b/functions/src/api/app.ts
@@ -57,8 +57,12 @@ app.use((req: Request, res: Response, next: NextFunction) => {
   const origin = req.headers.origin;
 
   if (isEmulator) {
-    // In emulator, allow any origin for local development
-    res.setHeader("Access-Control-Allow-Origin", origin || "*");
+    // Emulator: only allow localhost origins so that an accidental
+    // FUNCTIONS_EMULATOR=true in a non-local deploy can't open the API to
+    // every origin on the internet.
+    if (origin && /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
+      res.setHeader("Access-Control-Allow-Origin", origin);
+    }
   } else if (origin && ALLOWED_ORIGINS.has(origin)) {
     res.setHeader("Access-Control-Allow-Origin", origin);
   }

--- a/functions/src/api/routes/payments.ts
+++ b/functions/src/api/routes/payments.ts
@@ -21,6 +21,26 @@ import {cancelMpSubscription, getActiveOneOnOneLock} from "../services/enrollmen
 
 const router = Router();
 
+// MercadoPago redirects the buyer back to one of these URLs after checkout.
+// We derive the host from the caller's Origin header when it's in the trusted
+// allowlist (so staging redirects to staging, custom-domain redirects to the
+// custom domain) and fall back to the canonical production host otherwise.
+const PAYMENT_REDIRECT_ALLOWED_ORIGINS = new Set([
+  "https://wakelab.co",
+  "https://www.wakelab.co",
+  "https://wolf-20b8b.web.app",
+  "https://wolf-20b8b.firebaseapp.com",
+  "https://wake-staging.web.app",
+  "https://wake-staging.firebaseapp.com",
+]);
+const PAYMENT_REDIRECT_DEFAULT = "https://wakelab.co";
+
+function resolveAppBaseUrl(req: Request): string {
+  const origin = req.get("origin");
+  if (origin && PAYMENT_REDIRECT_ALLOWED_ORIGINS.has(origin)) return origin;
+  return PAYMENT_REDIRECT_DEFAULT;
+}
+
 function getMPClient() {
   const token = process.env.MERCADOPAGO_ACCESS_TOKEN;
   if (!token) {
@@ -138,11 +158,14 @@ router.post("/payments/preference", async (req, res) => {
         unit_price: course.price,
       }],
       external_reference: externalReference,
-      back_urls: {
-        success: `https://wolf-20b8b.web.app/app/payment/success?courseId=${courseId}`,
-        failure: `https://wolf-20b8b.web.app/app/payment/cancelled?courseId=${courseId}`,
-        pending: `https://wolf-20b8b.web.app/app/payment/cancelled?courseId=${courseId}`,
-      },
+      back_urls: (() => {
+        const base = resolveAppBaseUrl(req);
+        return {
+          success: `${base}/app/payment/success?courseId=${courseId}`,
+          failure: `${base}/app/payment/cancelled?courseId=${courseId}`,
+          pending: `${base}/app/payment/cancelled?courseId=${courseId}`,
+        };
+      })(),
       auto_return: "approved",
     },
   });
@@ -333,11 +356,14 @@ router.post("/payments/bundle-preference", async (req, res) => {
       }],
       external_reference: externalReference,
       metadata: {access_duration: "yearly"},
-      back_urls: {
-        success: `https://wolf-20b8b.web.app/app/payment/success?bundleId=${body.bundleId}`,
-        failure: `https://wolf-20b8b.web.app/app/payment/cancelled?bundleId=${body.bundleId}`,
-        pending: `https://wolf-20b8b.web.app/app/payment/cancelled?bundleId=${body.bundleId}`,
-      },
+      back_urls: (() => {
+        const base = resolveAppBaseUrl(req);
+        return {
+          success: `${base}/app/payment/success?bundleId=${body.bundleId}`,
+          failure: `${base}/app/payment/cancelled?bundleId=${body.bundleId}`,
+          pending: `${base}/app/payment/cancelled?bundleId=${body.bundleId}`,
+        };
+      })(),
       auto_return: "approved",
     },
   });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -622,7 +622,8 @@ export const processPaymentWebhook = functions
             expectedSignatureBuffer
           );
         } catch (compareError) {
-          functions.logger.error("Error comparing Mercado Pago signatures", compareError);
+          // Audit L-41: scrub raw error so webhook payload bytes don't leak.
+          functions.logger.error("Error comparing Mercado Pago signatures", safeErrorPayload(compareError));
           return false;
         }
       };
@@ -1713,11 +1714,12 @@ export const lookupUserForCreatorInvite = functions.https.onCall(
       );
     }
 
-    // Check caller is creator or admin
-    const creatorDoc = await db.collection("users").doc(creatorId).get();
-    const role = creatorDoc.exists ?
-      (creatorDoc.data()?.role as string | undefined) :
-      undefined;
+    // Check caller is creator or admin. Role is sourced from the verified
+    // ID-token custom claim (F-MW-08), matching the rest of the codebase.
+    // The Firestore users/{uid}.role field is no longer authoritative, and
+    // reading it here would (a) cost an extra Firestore read and (b) diverge
+    // from the claim-based check used by the Gen2 API.
+    const role = (context.auth.token as { role?: string }).role;
     if (role !== "creator" && role !== "admin") {
       throw new functions.https.HttpsError(
         "permission-denied",


### PR DESCRIPTION
## Summary
Round-3 security pass following a fresh codebase audit (no docs/ contamination). Fixes the verified findings from triage.

**Storage rules**
- `cards/{uid}`: cap video uploads at 500MB (was unbounded — billing/DoS vector)
- `creator_media`: require auth on read; tokened `<img>` URLs still work
- `profiles` + `profile_pictures`: drop role-based read branch that let any signed-in user enumerate the creator/admin roster by probing UIDs

**Firestore rules**
- `users/{uid}`: per-field length caps (bio, displayName, websiteUrl, howTheyFoundUs, city, country, phoneNumber) — bloat defense
- `bundles/{id}`: forbid `published → draft` transition (no publish/unpublish cycling)
- `event_signups/{eventId}/waitlist`: field allowlist matching registrations

**Cloud Functions**
- `payments.ts`: derive MercadoPago `back_urls` from request origin against trusted allowlist (was hardcoded to `wolf-20b8b.web.app`)
- `lookupUserForCreatorInvite`: read role from token claim instead of Firestore doc — matches F-MW-08 elsewhere
- Webhook signature compare error now wrapped with `safeErrorPayload()`
- Emulator CORS restricted to localhost origins

**Client**
- PWA + creator-dashboard `LoginScreen`: collapse user-not-found / wrong-password / invalid-credential into one generic credential message; password reset shows the same UI whether the email exists or not. Closes the email-enumeration side-channel.

## Test plan
- [ ] Rules emulator passes existing security suite
- [ ] Profile pics still load on creator surfaces (tokened URLs unaffected)
- [ ] `creator_media` images still load in program views (authed users)
- [ ] MercadoPago redirects land on the right host from each origin
- [ ] Login error message identical for unknown email vs wrong password
- [ ] Password reset shows success even for non-existent emails
- [ ] Bundle publish flow still works; un-publish (creator path) is now blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)