### PR TITLE
fix(pwa): suppress benign iOS Safari video AbortError from Error Tracking

### DIFF
--- a/apps/pwa/src/App.web.js
+++ b/apps/pwa/src/App.web.js
@@ -20,6 +20,18 @@ import analyticsService from './services/analyticsService';
 // Initialize analytics as early as possible (no-op when key missing or opted out).
 analyticsService.init();
 
+// expo-video's web player calls HTMLVideoElement.play() without handling the
+// returned promise (VideoPlayer.web.js). On iOS Safari an interrupted
+// play()/replace()/replay() (loop restart, pause-after-play, source swap,
+// unmount on navigation) rejects with a benign "AbortError: The operation was
+// aborted." Since player.play() returns void, it can't be caught at the call
+// site — mark it handled here so it doesn't surface as an unhandled rejection.
+if (typeof window !== 'undefined') {
+  window.addEventListener('unhandledrejection', (event) => {
+    if (event?.reason?.name === 'AbortError') event.preventDefault();
+  });
+}
+
 // Normalize a trailing slash on the entry path before BrowserRouter reads
 // location.pathname. React Router v6 treats `/app/payment/success/` as
 // distinct from `/app/payment/success` and falls through to the catch-all

--- a/apps/pwa/src/services/analyticsService.js
+++ b/apps/pwa/src/services/analyticsService.js
@@ -75,6 +75,23 @@ function writeOptOut(v) {
   } catch {}
 }
 
+// Drop benign DOMException AbortErrors from Error Tracking. expo-video's web
+// player discards the HTMLVideoElement.play() promise, so an interrupted
+// play()/replace()/replay() surfaces on iOS Safari as an unhandled
+// "AbortError: The operation was aborted." It's expected (interrupted playback),
+// not a real error, and can't be caught at the call site (player.play() returns
+// void). Our own fetch aborts are already translated to WakeApiError upstream,
+// so a raw AbortError reaching here is always this benign media case.
+function dropBenignAbortErrors(event) {
+  if (event?.event === '$exception') {
+    const list = event.properties?.$exception_list;
+    if (Array.isArray(list) && list.some((e) => e?.type === 'AbortError')) {
+      return null;
+    }
+  }
+  return event;
+}
+
 function init() {
   if (initAttempted) return;
   initAttempted = true;
@@ -93,6 +110,7 @@ function init() {
       capture_pageview: 'history_change',
       capture_pageleave: true,
       capture_exceptions: true,
+      before_send: dropBenignAbortErrors,
       disable_session_recording: false,
       session_recording: {
         maskAllInputs: true,

--- a/functions/lib/landing-index.html
+++ b/functions/lib/landing-index.html
@@ -24,7 +24,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-BGRtjmfR.js"></script>
+    <script type="module" crossorigin src="/assets/index-WBnouSy-.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D_9PU5bc.css">
   </head>
   <body>


### PR DESCRIPTION
## Context
After enabling PostHog Error Tracking, one issue dominated: **`DOMException — AbortError: The operation was aborted.`** — 18 occurrences / 3 users, all Mobile Safari / iOS, on `/app`, `/app/warmup`, and `/workout/execution`.

## Root cause (expo-video web limitation)
`expo-video`'s web player discards the play promise:
```js
// expo-video/build/VideoPlayer.web.js
play() { this._mountedVideos.forEach((video) => { video.play(); }); } // promise never caught
```
On iOS Safari, an interrupted `play()`/`replace()`/`replay()` (loop restart, pause-after-play, source swap, unmount on navigation) rejects with `AbortError`. Since `player.play()` returns `void`, it can't be `.catch()`-ed at the call site (e.g. `WarmupScreen.js`), so it escaped as an unhandled rejection.

Ruled out: `apiClient` / `sessionManager` abort paths (both translate to `REQUEST_CANCELLED` and are caught) and the raw `el.play()` calls in `WorkoutExecutionScreen` (already guarded).

## Fix (benign — suppress, don't surface)
- `analyticsService.js`: `before_send` drops `$exception` events whose type is `AbortError`. Safe — real fetch aborts are translated to `WakeApiError` upstream, so a raw `AbortError` here is always this media case.
- `App.web.js`: global `unhandledrejection` listener `preventDefault()`s benign `AbortError`s (marks handled, quiets console).

## Verification
- `build:all` clean; prod-bundle verifier passed; handling present in assembled bundle.
- Deployed to prod (hosting-only); will re-check the issue count goes quiet over the next day.

Note: includes one stray `deploy(functions)` marker commit from the prior deploy (the postdeploy hook couldn't auto-push it due to the branch rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)