### PR TITLE
feat(workout): live session timer in header

### DIFF
--- a/apps/pwa/src/components/WakeHeader.web.jsx
+++ b/apps/pwa/src/components/WakeHeader.web.jsx
@@ -86,7 +86,8 @@ export const FixedWakeHeader = ({
   showMenuButton = false,
   onMenuPress = null,
   menuButton = null,
-  backgroundColor = '#1a1a1a'
+  backgroundColor = '#1a1a1a',
+  sessionElapsedSeconds = null
 }) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -305,8 +306,31 @@ export const FixedWakeHeader = ({
         </button>
       )}
 
+      {/* Session timer - replaces the streak badge during a workout. Live MM:SS of
+          total session time, surfaced from WorkoutExecutionScreen. */}
+      {sessionElapsedSeconds != null && (
+        <div
+          aria-label="Tiempo de sesión"
+          style={{
+            position: 'absolute',
+            top: barCenterTop,
+            right: Math.max(32, screenWidth * 0.08),
+            transform: 'translateY(-50%)',
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            zIndex: 1001,
+          }}
+        >
+          <span style={{ color: '#ffffff', fontSize: 16, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>
+            {String(Math.floor(sessionElapsedSeconds / 60)).padStart(2, '0')}:{String(sessionElapsedSeconds % 60).padStart(2, '0')}
+          </span>
+        </div>
+      )}
+
       {/* Streak badge - same structure as DailyWorkoutScreen (base / middle / inner), slightly larger.
           Click to open streak details modal. */}
+      {sessionElapsedSeconds == null && (
       <div
         aria-label="Racha"
         role="button"
@@ -351,7 +375,8 @@ export const FixedWakeHeader = ({
           {streakDisplayNum}
         </span>
       </div>
-      
+      )}
+
       {/* Reset Button - aligned with logo center */}
       {showResetButton && onResetPress && (
         <button

--- a/apps/pwa/src/screens/WorkoutExecutionScreen.js
+++ b/apps/pwa/src/screens/WorkoutExecutionScreen.js
@@ -2887,6 +2887,21 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
     return () => clearTimeout(t);
   }, [isTimerModalVisible]);
 
+  // Session timer: tick total elapsed every second for the whole session, so the
+  // header readout stays live even when the rest-timer modal is closed. Recomputes
+  // from the start ref (set on mount / restored from checkpoint) so reloads keep counting.
+  useEffect(() => {
+    const tick = () => {
+      const start = workoutStartTimeRef.current;
+      if (start != null) {
+        setTotalElapsedSeconds(Math.floor((Date.now() - start) / 1000));
+      }
+    };
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, []);
+
   // Timer modal: tick total time and rest countdown every second when modal is visible
   useEffect(() => {
     if (!isTimerModalVisible) return;
@@ -5436,6 +5451,7 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
         onMenuPress={() => {
           setIsMenuVisible(true);
         }}
+        sessionElapsedSeconds={totalElapsedSeconds}
       />
 
       {/* Post-save ring+check overlay (web only) */}


### PR DESCRIPTION
## What

Replaces the streak badge with an always-counting **MM:SS** session timer in the WorkoutExecutionScreen header (web PWA only).

## Why

Surfaces elapsed session time at the top of the screen during a workout, which is more relevant mid-set than the streak flame.

## How

- **WorkoutExecutionScreen.js** — adds an always-on 1s tick that keeps `totalElapsedSeconds` live for the whole session (previously it only updated while the rest-timer modal was open). Recomputes from `workoutStartTimeRef`, so reloads/recovery keep counting. Passes `sessionElapsedSeconds` to the header.
- **WakeHeader.web.jsx** — new `sessionElapsedSeconds` prop; when set, renders a compact `MM:SS` readout in the right slot and hides the streak badge. No effect on other screens.

No new state or persistence — surfaces what was already tracked.

## Notes

- Production hosting was already deployed with these changes (live at https://wolf-20b8b.web.app). This PR brings `main` in sync, since branch protection blocked the deploy script's direct push.
- Web header only; native `WakeHeader.js` ignores the prop and keeps the streak.
- Format is `MM:SS` (a 72-min session reads `72:00`), matching the existing rest-timer modal display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)