### PR TITLE
consolidate: subscription email/checkout + fix subscriptions.status index

### DIFF
--- a/apps/landing/src/screens/CreatorProgramDetailScreen.jsx
+++ b/apps/landing/src/screens/CreatorProgramDetailScreen.jsx
@@ -8,6 +8,7 @@ import {
   StorefrontCheckoutError,
 } from '../services/storefrontCheckoutService';
 import { getCurrentUser } from '../services/storefrontAuthService';
+import analyticsService from '../services/analyticsService';
 import { useAccentFromImage } from '../utils/accentColor';
 import AuthModal from '../components/AuthModal';
 import './CreatorProgramDetailScreen.css';
@@ -131,6 +132,10 @@ export default function CreatorProgramDetailScreen() {
   const [checkoutError, setCheckoutError] = useState(null);
   const [altEmail, setAltEmail] = useState('');
   const [needsAltEmail, setNeedsAltEmail] = useState(false);
+  // Proactive subscription email confirm step: false = hidden; when true,
+  // one-tap confirm of the account email or switch to a custom MP email.
+  const [emailStep, setEmailStep] = useState(false);
+  const [useCustomEmail, setUseCustomEmail] = useState(false);
   const [alreadyOwned, setAlreadyOwned] = useState(null);
   // Sold-out waitlist: 'hidden' (just the CTA) | 'form' | 'done'.
   const [waitlistPhase, setWaitlistPhase] = useState('hidden');
@@ -284,6 +289,15 @@ export default function CreatorProgramDetailScreen() {
             window.sessionStorage.setItem(`wake_payer_${program.id}`, payer);
           }
         } catch { /* private mode — fall through */ }
+        if (mode === 'subscription') {
+          try {
+            analyticsService.track('subscription.checkout.redirected', {
+              course_id: program.id,
+              surface: 'landing',
+              subscription_id: result.subscriptionId || null,
+            });
+          } catch { /* analytics is best-effort */ }
+        }
         window.location.href = result.initPoint;
         return;
       }
@@ -308,9 +322,21 @@ export default function CreatorProgramDetailScreen() {
     window.location.href = url;
   };
 
+  // Subscriptions: confirm the Mercado Pago email BEFORE creating the
+  // preapproval (it binds to that email and can't be re-bound). One-time
+  // payments go straight to checkout.
+  const startForMode = (mode) => {
+    if (mode === 'subscription') {
+      openEmailStep();
+    } else {
+      runCheckout(mode);
+    }
+  };
+
   const handleBuy = (mode) => {
     setCheckoutError(null);
     setNeedsAltEmail(false);
+    setEmailStep(false);
     setAlreadyOwned(null);
     setAltEmail('');
     setPendingMode(mode);
@@ -325,7 +351,7 @@ export default function CreatorProgramDetailScreen() {
       return;
     }
     if (getCurrentUser()) {
-      runCheckout(mode);
+      startForMode(mode);
     } else {
       setAuthOpen(true);
     }
@@ -338,8 +364,43 @@ export default function CreatorProgramDetailScreen() {
       return;
     }
     if (pendingMode) {
-      runCheckout(pendingMode);
+      startForMode(pendingMode);
     }
+  };
+
+  const openEmailStep = () => {
+    setEmailStep(true);
+    setUseCustomEmail(false);
+    setAltEmail('');
+    setCheckoutError(null);
+    try {
+      analyticsService.track('subscription.email_step.shown', {
+        course_id: program.id,
+        surface: 'landing',
+      });
+    } catch { /* analytics is best-effort */ }
+  };
+
+  const confirmEmailStep = (e) => {
+    if (e) e.preventDefault();
+    const accountEmail = (getCurrentUser()?.email || '').trim().toLowerCase();
+    const chosen = useCustomEmail ? altEmail.trim().toLowerCase() : accountEmail;
+    if (!EMAIL_RE.test(chosen)) {
+      setCheckoutError('Correo inválido.');
+      return;
+    }
+    try {
+      analyticsService.track('subscription.email_step.choice', {
+        course_id: program.id,
+        surface: 'landing',
+        choice: useCustomEmail ? 'custom' : 'account',
+        emails_differ: chosen !== accountEmail,
+      });
+    } catch { /* analytics is best-effort */ }
+    setEmailStep(false);
+    // Pass an override only for a custom email; undefined lets the backend
+    // default to the account email (and tag emailType "account").
+    runCheckout('subscription', useCustomEmail ? chosen : undefined);
   };
 
   const submitAltEmail = (e) => {
@@ -543,7 +604,7 @@ export default function CreatorProgramDetailScreen() {
                 </>
               )}
             </div>
-          ) : needsAltEmail ? null : (
+          ) : (needsAltEmail || emailStep) ? null : (
             // Hide the primary CTAs while the alt-email form is showing. Both
             // buttons remained visible and clickable, so a user could re-fire
             // a subscription attempt with the wrong email and loop the same
@@ -597,6 +658,67 @@ export default function CreatorProgramDetailScreen() {
                 <span className="cpd-cta-label">Abrir en la app</span>
               </a>
             </div>
+          ) : null}
+
+          {emailStep ? (
+            <form className="cpd-alt-email" onSubmit={confirmEmailStep}>
+              <p className="cpd-alt-email-label">
+                Usa este mismo correo al iniciar sesión en Mercado Pago para completar tu suscripción.
+              </p>
+              {useCustomEmail ? (
+                <input
+                  type="email"
+                  className="cpd-alt-email-input"
+                  placeholder="correo@mercadopago.com"
+                  value={altEmail}
+                  onChange={(e) => setAltEmail(e.target.value)}
+                  maxLength={254}
+                  required
+                  autoFocus
+                  disabled={busyMode !== null}
+                />
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: '12px 14px', background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 10, marginBottom: 8 }}>
+                  <span style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'rgba(255,255,255,0.4)' }}>Tu correo</span>
+                  <span style={{ fontSize: 15, color: 'rgba(255,255,255,0.95)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {getCurrentUser()?.email || ''}
+                  </span>
+                </div>
+              )}
+              <button
+                type="submit"
+                className="cpd-cta cpd-cta-primary"
+                disabled={busyMode !== null}
+              >
+                <span className="cpd-cta-label">
+                  {busyMode !== null ? 'Procesando…' : (useCustomEmail ? 'Continuar' : 'Continuar con este correo')}
+                </span>
+              </button>
+              {!useCustomEmail ? (
+                <button
+                  type="button"
+                  className="cpd-alt-email-cancel"
+                  onClick={() => { setUseCustomEmail(true); setAltEmail(''); setCheckoutError(null); }}
+                  disabled={busyMode !== null}
+                >
+                  Usar otro correo de Mercado Pago
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="cpd-alt-email-cancel"
+                onClick={() => {
+                  setEmailStep(false);
+                  setUseCustomEmail(false);
+                  setAltEmail('');
+                  setCheckoutError(null);
+                  setPendingMode(null);
+                }}
+                disabled={busyMode !== null}
+              >
+                Cancelar
+              </button>
+            </form>
           ) : null}
 
           {needsAltEmail ? (

--- a/apps/landing/src/screens/PostPaymentScreen.jsx
+++ b/apps/landing/src/screens/PostPaymentScreen.jsx
@@ -6,6 +6,7 @@ import { getCreatorProgram } from '../services/creatorStorefrontService';
 import { getCheckoutStatus } from '../services/storefrontCheckoutService';
 import { requestMagicLink } from '../services/magicLinkService';
 import { getCurrentIdToken } from '../services/storefrontAuthService';
+import analyticsService from '../services/analyticsService';
 import { getDownloadUrl, getDownloadLabel } from '../utils/smartDownload';
 import './PostPaymentScreen.css';
 
@@ -74,6 +75,7 @@ export default function PostPaymentScreen() {
   // access async; we don't wait).
   const [magicLinkState, setMagicLinkState] = useState('idle'); // idle | sending | sent | failed
   const magicLinkFiredRef = useRef(false);
+  const returnedFiredRef = useRef(false);
   // Firebase restores persisted auth asynchronously; until the first
   // onAuthStateChanged fires we don't know whether the user is signed in
   // or signed out. We must NOT trust the first `null` callback as
@@ -87,6 +89,22 @@ export default function PostPaymentScreen() {
   const [fallbackEmail, setFallbackEmail] = useState('');
   const [fallbackState, setFallbackState] = useState('idle'); // idle | sending | sent | error
   const [fallbackError, setFallbackError] = useState('');
+
+  // Fire once when the buyer lands back from MercadoPago on a subscription
+  // checkout — the "returned" end of the funnel (pairs with
+  // subscription.email_step.shown / choice / .checkout.redirected). Both PWA
+  // and storefront subscriptions redirect here.
+  useEffect(() => {
+    if (!isSubscription || returnedFiredRef.current) return;
+    returnedFiredRef.current = true;
+    try {
+      analyticsService.track('subscription.checkout.returned', {
+        course_id: courseId,
+        surface: 'post_payment',
+        status: status || null,
+      });
+    } catch { /* analytics is best-effort */ }
+  }, [isSubscription, courseId, status]);
 
   // Subscribe to auth state — `auth.currentUser` is null until Firebase
   // restores the session asynchronously after a hard reload. Use a grace

--- a/apps/pwa/src/components/TodayWorkoutCard.web.jsx
+++ b/apps/pwa/src/components/TodayWorkoutCard.web.jsx
@@ -357,6 +357,11 @@ const styles = {
     color: 'rgba(255,255,255,0.4)',
     cursor: 'not-allowed',
   },
+  beginSecondary: {
+    backgroundColor: 'transparent',
+    color: 'rgba(255,255,255,0.85)',
+    border: '1px solid rgba(255,255,255,0.18)',
+  },
   loaderOverlay: {
     position: 'absolute',
     inset: 0,
@@ -531,21 +536,24 @@ const TodayWorkoutCard = ({ course, isExpired = false, downloadStatus = null, se
     setFlipped((f) => !f);
   };
 
-  const handleBegin = (e) => {
+  const handleBegin = (e, mode = 'new') => {
     e?.stopPropagation?.();
     if (isExpired) {
       onRenew?.(course);
       return;
     }
-    if (!canBegin || !onBegin) return;
+    // Completed sessions offer both modes; otherwise require the normal begin gate.
+    if (!sessionState?.workout || !onBegin) return;
+    if (!isCompleted && !canBegin) return;
     onBegin({
       course,
       workout: sessionState?.workout,
       sessionId: sessionState?.session?.sessionId,
+      mode,
     });
   };
 
-  const beginAccentStyle = accent && (canBegin || isExpired)
+  const beginAccentStyle = accent && (canBegin || isExpired || isCompleted)
     ? { backgroundColor: accent.accent, color: accent.accentText }
     : null;
   const beginStyle = canBegin
@@ -699,15 +707,34 @@ const TodayWorkoutCard = ({ course, isExpired = false, downloadStatus = null, se
             </div>
 
             <div style={styles.beginRow}>
-              <button
-                style={canBegin || isExpired
-                  ? { ...styles.beginButton, ...(beginAccentStyle || {}) }
-                  : beginStyle}
-                onClick={handleBegin}
-                disabled={(!canBegin && !isExpired) || sessionLoading}
-              >
-                {beginLabel}
-              </button>
+              {isCompleted && !isExpired ? (
+                <>
+                  <button
+                    style={{ ...styles.beginButton, ...(beginAccentStyle || {}) }}
+                    onClick={(e) => handleBegin(e, 'reopen')}
+                    disabled={sessionLoading || !sessionState?.workout}
+                  >
+                    Continuar sesión
+                  </button>
+                  <button
+                    style={{ ...styles.beginButton, ...styles.beginSecondary }}
+                    onClick={(e) => handleBegin(e, 'new')}
+                    disabled={sessionLoading || !sessionState?.workout}
+                  >
+                    Empezar de nuevo
+                  </button>
+                </>
+              ) : (
+                <button
+                  style={canBegin || isExpired
+                    ? { ...styles.beginButton, ...(beginAccentStyle || {}) }
+                    : beginStyle}
+                  onClick={(e) => handleBegin(e, 'new')}
+                  disabled={(!canBegin && !isExpired) || sessionLoading}
+                >
+                  {beginLabel}
+                </button>
+              )}
             </div>
 
           </div>

--- a/apps/pwa/src/screens/BundleDetailScreen.web.jsx
+++ b/apps/pwa/src/screens/BundleDetailScreen.web.jsx
@@ -4,6 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import apiClient from '../utils/apiClient';
 import { useAuth } from '../contexts/AuthContext';
 import purchaseService from '../services/purchaseService';
+import analyticsService from '../services/analyticsService';
+import logger from '../utils/logger';
 import LoadingScreen from './LoadingScreen';
 import BundleCoverWeb from '../components/bundles/BundleCover.web';
 
@@ -29,6 +31,8 @@ const BundleDetailScreen = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
   const [checkoutState, setCheckoutState] = useState({ kind: null, key: null, loading: false, error: null });
+  // Proactive subscription email step: { email, useCustom, error, submitting } or null.
+  const [emailStep, setEmailStep] = useState(null);
 
   const { data: bundle, isLoading, error } = useQuery({
     queryKey: ['bundle', bundleId],
@@ -60,15 +64,20 @@ const BundleDetailScreen = () => {
       navigate('/login');
       return;
     }
+    // Subscriptions: confirm the Mercado Pago email BEFORE creating the
+    // preapproval (it binds to that email and can't be re-bound). One-time
+    // payments skip this.
+    if (kind === 'sub') {
+      setEmailStep({ email: user?.email || '', useCustom: false, error: null, submitting: false });
+      try {
+        analyticsService.track('subscription.email_step.shown', { bundle_id: bundleId, surface: 'pwa_web' });
+      } catch {}
+      logger.info('[subscription] email step shown (bundle)', { bundleId });
+      return;
+    }
     setCheckoutState({ kind, loading: true, error: null });
     try {
-      let result;
-      if (kind === 'otp') {
-        result = await purchaseService.prepareBundlePurchase(bundleId);
-      } else {
-        const payerEmail = user?.email || null;
-        result = await purchaseService.prepareBundleSubscription(bundleId, payerEmail);
-      }
+      const result = await purchaseService.prepareBundlePurchase(bundleId);
       if (result.success && result.checkoutURL) {
         window.location.href = result.checkoutURL;
       } else {
@@ -79,6 +88,52 @@ const BundleDetailScreen = () => {
       }
     } catch (err) {
       setCheckoutState({ kind, loading: false, error: err.message || 'Error' });
+    }
+  };
+
+  const confirmSubEmail = async () => {
+    if (!emailStep) return;
+    const chosen = (emailStep.email || '').trim();
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(chosen)) {
+      setEmailStep((s) => ({ ...s, error: 'Correo inválido.' }));
+      return;
+    }
+    const accountEmail = (user?.email || '').trim();
+    const emailsDiffer = chosen.toLowerCase() !== accountEmail.toLowerCase();
+    try {
+      analyticsService.track('subscription.email_step.choice', {
+        bundle_id: bundleId,
+        surface: 'pwa_web',
+        choice: emailStep.useCustom ? 'custom' : 'account',
+        emails_differ: emailsDiffer,
+      });
+    } catch {}
+    logger.info('[subscription] email step choice (bundle)', {
+      bundleId, choice: emailStep.useCustom ? 'custom' : 'account', emailsDiffer,
+    });
+    setEmailStep((s) => ({ ...s, submitting: true, error: null }));
+    try {
+      const result = await purchaseService.prepareBundleSubscription(bundleId, chosen, 'pwa_web');
+      if (result.success && result.checkoutURL) {
+        try {
+          analyticsService.track('subscription.checkout.redirected', {
+            bundle_id: bundleId, surface: 'pwa_web', subscription_id: result.subscriptionId || null,
+          });
+        } catch {}
+        logger.info('[subscription] checkout redirected (bundle)', {
+          bundleId, subscriptionId: result.subscriptionId || null,
+        });
+        window.location.href = result.checkoutURL;
+        return;
+      }
+      if (result.requiresAlternateEmail) {
+        setEmailStep((s) => ({ ...s, useCustom: true, submitting: false, error: result.error || 'Ingresa tu correo de Mercado Pago.' }));
+      } else {
+        setEmailStep((s) => ({ ...s, submitting: false, error: result.error || 'No pudimos iniciar el pago.' }));
+      }
+    } catch (err) {
+      setEmailStep((s) => ({ ...s, submitting: false, error: err.message || 'Error' }));
     }
   };
 
@@ -155,6 +210,49 @@ const BundleDetailScreen = () => {
           <div style={styles.loadingBanner}>Preparando el pago…</div>
         )}
       </div>
+
+      {emailStep && (
+        <div style={styles.modalOverlay} onClick={() => setEmailStep(null)}>
+          <div style={styles.modalCard} onClick={(e) => e.stopPropagation()}>
+            <h3 style={styles.modalTitle}>Confirma tu correo de Mercado Pago</h3>
+            <p style={styles.modalDesc}>
+              Usa este mismo correo al iniciar sesión en Mercado Pago para completar tu suscripción.
+            </p>
+            {emailStep.useCustom ? (
+              <input
+                style={styles.modalInput}
+                type="email"
+                placeholder="correo@mercadopago.com"
+                value={emailStep.email}
+                onChange={(e) => setEmailStep((s) => ({ ...s, email: e.target.value, error: null }))}
+                autoFocus
+              />
+            ) : (
+              <div style={styles.emailCard}>
+                <span style={styles.emailCardLabel}>Tu correo</span>
+                <span style={styles.emailCardValue}>{emailStep.email}</span>
+              </div>
+            )}
+            {emailStep.error && <p style={styles.modalError}>{emailStep.error}</p>}
+            <div style={styles.modalButtons}>
+              <button style={styles.modalCancel} onClick={() => setEmailStep(null)} disabled={emailStep.submitting}>
+                Cancelar
+              </button>
+              <button style={styles.modalConfirm} onClick={confirmSubEmail} disabled={emailStep.submitting}>
+                {emailStep.submitting ? 'Procesando…' : (emailStep.useCustom ? 'Continuar' : 'Continuar con este correo')}
+              </button>
+            </div>
+            {!emailStep.useCustom && (
+              <button
+                style={styles.modalSecondary}
+                onClick={() => setEmailStep((s) => ({ ...s, useCustom: true, email: '', error: null }))}
+              >
+                Usar otro correo de Mercado Pago
+              </button>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 };
@@ -328,6 +426,110 @@ const styles = {
     color: 'rgba(255,255,255,0.75)',
     fontSize: 13,
     textAlign: 'center',
+  },
+  modalOverlay: {
+    position: 'fixed',
+    inset: 0,
+    background: 'rgba(0,0,0,0.7)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 9999,
+    padding: 20,
+  },
+  modalCard: {
+    background: '#222',
+    border: '1px solid rgba(255,255,255,0.12)',
+    borderRadius: 16,
+    padding: 24,
+    width: '100%',
+    maxWidth: 380,
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: 700,
+    margin: '0 0 8px',
+  },
+  modalDesc: {
+    fontSize: 13,
+    color: 'rgba(255,255,255,0.6)',
+    margin: '0 0 16px',
+    lineHeight: 1.5,
+  },
+  modalInput: {
+    width: '100%',
+    boxSizing: 'border-box',
+    padding: '12px 14px',
+    background: 'rgba(255,255,255,0.06)',
+    border: '1px solid rgba(255,255,255,0.18)',
+    borderRadius: 10,
+    color: '#fff',
+    fontSize: 15,
+  },
+  emailCard: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+    padding: '12px 14px',
+    background: 'rgba(255,255,255,0.06)',
+    border: '1px solid rgba(255,255,255,0.12)',
+    borderRadius: 10,
+  },
+  emailCardLabel: {
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    color: 'rgba(255,255,255,0.4)',
+  },
+  emailCardValue: {
+    fontSize: 15,
+    color: 'rgba(255,255,255,0.95)',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  modalError: {
+    color: 'rgba(255,180,180,0.95)',
+    fontSize: 13,
+    margin: '12px 0 0',
+  },
+  modalButtons: {
+    display: 'flex',
+    gap: 10,
+    marginTop: 20,
+  },
+  modalCancel: {
+    flex: 1,
+    padding: '12px',
+    background: 'rgba(255,255,255,0.06)',
+    border: '1px solid rgba(255,255,255,0.15)',
+    borderRadius: 100,
+    color: 'rgba(255,255,255,0.7)',
+    fontSize: 14,
+    fontWeight: 600,
+    cursor: 'pointer',
+  },
+  modalConfirm: {
+    flex: 2,
+    padding: '12px',
+    background: 'rgba(255,255,255,0.92)',
+    border: 'none',
+    borderRadius: 100,
+    color: '#111',
+    fontSize: 14,
+    fontWeight: 700,
+    cursor: 'pointer',
+  },
+  modalSecondary: {
+    display: 'block',
+    width: '100%',
+    marginTop: 14,
+    background: 'none',
+    border: 'none',
+    color: 'rgba(255,255,255,0.55)',
+    fontSize: 13,
+    fontWeight: 600,
+    cursor: 'pointer',
   },
 };
 

--- a/apps/pwa/src/screens/CourseDetailScreen.js
+++ b/apps/pwa/src/screens/CourseDetailScreen.js
@@ -39,6 +39,7 @@ import EpaycoWebView from '../components/EpaycoWebView';
 import BookCallSlotModal from '../components/BookCallSlotModal';
 import { getBookingForUser } from '../services/callBookingService';
 import logger from '../utils/logger.js';
+import analyticsService from '../services/analyticsService';
 import { STALE_TIMES } from '../config/queryConfig';
 import { auth } from '../config/firebase';
 import profilePictureService from '../services/profilePictureService';
@@ -105,6 +106,9 @@ const CourseDetailScreen = ({ navigation, route }) => {
   const [showEmailModal, setShowEmailModal] = useState(false);
   const [mercadoPagoEmail, setMercadoPagoEmail] = useState('');
   const [emailModalError, setEmailModalError] = useState('');
+  // Proactive subscription email step: false = one-tap confirm of the account
+  // email; true = user chose to type a different Mercado Pago email.
+  const [useCustomEmail, setUseCustomEmail] = useState(false);
   const [preCheckout, setPreCheckout] = useState(null); // { checkoutURL, mode: 'web'|'native' }
   const [showBookCallModal, setShowBookCallModal] = useState(false);
   const [userCallBooking, setUserCallBooking] = useState(null);
@@ -826,6 +830,26 @@ useEffect(() => {
       return; // Exit early - free flow handled
     }
 
+    // Subscriptions: choose/confirm the Mercado Pago email BEFORE creating the
+    // preapproval, so it binds to the email the user will actually authorize
+    // with (the preapproval can't be re-bound afterwards). One-time payments
+    // skip this — MP's preference checkout accepts any email.
+    const isSubscriptionPurchase = course.access_duration === 'monthly';
+    if (isSubscriptionPurchase) {
+      setMercadoPagoEmail(effectiveUser.email || '');
+      setUseCustomEmail(false);
+      setEmailModalError('');
+      setShowEmailModal(true);
+      try {
+        analyticsService.track('subscription.email_step.shown', {
+          course_id: course.id,
+          surface: isWeb ? 'pwa_web' : 'pwa_native',
+        });
+      } catch {}
+      logger.info('[subscription] email step shown', { courseId: course.id });
+      return;
+    }
+
     // Regular purchase flow - open payment modal
     try {
       setPurchasing(true);
@@ -941,8 +965,26 @@ useEffect(() => {
 
     setEmailModalError('');
     setShowEmailModal(false);
-    
-    // Retry purchase with the provided email
+
+    const chosenEmail = mercadoPagoEmail.trim();
+    const accountEmail = (effectiveUser.email || '').trim();
+    const emailsDiffer = chosenEmail.toLowerCase() !== accountEmail.toLowerCase();
+    const surface = isWeb ? 'pwa_web' : 'pwa_native';
+    try {
+      analyticsService.track('subscription.email_step.choice', {
+        course_id: course.id,
+        surface,
+        choice: useCustomEmail ? 'custom' : 'account',
+        emails_differ: emailsDiffer,
+      });
+    } catch {}
+    logger.info('[subscription] email step choice', {
+      courseId: course.id,
+      choice: useCustomEmail ? 'custom' : 'account',
+      emailsDiffer,
+    });
+
+    // Proceed to subscription checkout with the chosen email.
     try {
       setPurchasing(true);
       setProcessingPurchase(true);
@@ -952,16 +994,19 @@ useEffect(() => {
       readyNotificationSentRef.current = false;
       successAlertShownRef.current = false;
 
-      // Call prepareSubscription directly with the provided email
+      // Call prepareSubscription directly with the chosen email.
       const subscriptionResult = await purchaseService.prepareSubscription(
         effectiveUser.uid,
         course.id,
-        mercadoPagoEmail.trim()
+        chosenEmail,
+        surface
       );
 
       if (!subscriptionResult.success) {
         if (subscriptionResult.requiresAlternateEmail) {
-          // Still requires alternate email - show modal again
+          // MP rejected the email at creation — re-prompt, forcing the custom
+          // input so the user can correct it.
+          setUseCustomEmail(true);
           setShowEmailModal(true);
           setEmailModalError(subscriptionResult.error || 'Este correo no es válido para Mercado Pago. Por favor intenta con otro.');
         } else {
@@ -973,6 +1018,18 @@ useEffect(() => {
         pendingPostPurchaseRef.current = false;
         return;
       }
+
+      try {
+        analyticsService.track('subscription.checkout.redirected', {
+          course_id: course.id,
+          surface,
+          subscription_id: subscriptionResult.subscriptionId || null,
+        });
+      } catch {}
+      logger.info('[subscription] checkout redirected', {
+        courseId: course.id,
+        subscriptionId: subscriptionResult.subscriptionId || null,
+      });
 
       // On web: open MP in a new tab so installed PWAs (iOS standalone) work.
       if (isWeb) {
@@ -1611,42 +1668,51 @@ useEffect(() => {
           }}
         >
           <Pressable style={styles.emailModalContent} onPress={(e) => e.stopPropagation()}>
-            <Text style={styles.emailModalTitle}>Correo de Mercado Pago</Text>
+            <Text style={styles.emailModalTitle}>Confirma tu correo de Mercado Pago</Text>
             <Text style={styles.emailModalDescription}>
-              Mercado Pago necesita un correo distinto para la suscripción. Tu compra se vinculará automáticamente a tu cuenta Wake.
+              Usa este mismo correo al iniciar sesión en Mercado Pago para completar tu suscripción.
             </Text>
-            
-            <TextInput
-              style={[styles.emailModalInput, emailModalError && styles.emailModalInputError]}
-              placeholder="correo@mercadopago.com"
-              placeholderTextColor="rgba(255, 255, 255, 0.5)"
-              value={mercadoPagoEmail}
-              onChangeText={(text) => {
-                setMercadoPagoEmail(text);
-                setEmailModalError('');
-              }}
-              keyboardType="email-address"
-              autoCapitalize="none"
-              autoCorrect={false}
-              autoFocus={true}
-            />
-            
+
+            {useCustomEmail ? (
+              <TextInput
+                style={[styles.emailModalInput, emailModalError && styles.emailModalInputError]}
+                placeholder="correo@mercadopago.com"
+                placeholderTextColor="rgba(255, 255, 255, 0.5)"
+                value={mercadoPagoEmail}
+                onChangeText={(text) => {
+                  setMercadoPagoEmail(text);
+                  setEmailModalError('');
+                }}
+                keyboardType="email-address"
+                autoCapitalize="none"
+                autoCorrect={false}
+                autoFocus={true}
+              />
+            ) : (
+              <View style={styles.preCheckoutEmailCard}>
+                <Text style={styles.preCheckoutEmailLabel}>Tu correo</Text>
+                <Text style={styles.preCheckoutEmailValue} numberOfLines={1}>
+                  {mercadoPagoEmail}
+                </Text>
+              </View>
+            )}
+
             {emailModalError ? (
               <Text style={styles.emailModalErrorText}>{emailModalError}</Text>
             ) : null}
-            
+
             <View style={styles.emailModalButtons}>
               <TouchableOpacity
                 style={[styles.emailModalButton, styles.emailModalButtonCancel]}
                 onPress={() => {
                   setShowEmailModal(false);
                   setEmailModalError('');
-                  setMercadoPagoEmail('');
+                  setUseCustomEmail(false);
                 }}
               >
                 <Text style={styles.emailModalButtonCancelText}>Cancelar</Text>
               </TouchableOpacity>
-              
+
               <TouchableOpacity
                 style={[styles.emailModalButton, styles.emailModalButtonSubmit]}
                 onPress={handleEmailSubmit}
@@ -1655,10 +1721,25 @@ useEffect(() => {
                 {purchasing ? (
                   <ActivityIndicator size="small" color="rgba(255, 255, 255, 1)" />
                 ) : (
-                  <Text style={styles.emailModalButtonSubmitText}>Continuar</Text>
+                  <Text style={styles.emailModalButtonSubmitText}>
+                    {useCustomEmail ? 'Continuar' : 'Continuar con este correo'}
+                  </Text>
                 )}
               </TouchableOpacity>
             </View>
+
+            {!useCustomEmail ? (
+              <TouchableOpacity
+                style={styles.emailModalSecondaryLink}
+                onPress={() => {
+                  setUseCustomEmail(true);
+                  setMercadoPagoEmail('');
+                  setEmailModalError('');
+                }}
+              >
+                <Text style={styles.emailModalSecondaryLinkText}>Usar otro correo de Mercado Pago</Text>
+              </TouchableOpacity>
+            ) : null}
           </Pressable>
         </Pressable>
       </Modal>
@@ -2755,6 +2836,15 @@ const createStyles = (screenWidth, screenHeight) => StyleSheet.create({
     color: 'rgba(255, 255, 255, 1)',
     fontSize: Math.min(screenWidth * 0.045, 18),
     fontWeight: '700',
+  },
+  emailModalSecondaryLink: {
+    marginTop: 16,
+    alignItems: 'center',
+  },
+  emailModalSecondaryLinkText: {
+    color: 'rgba(255, 255, 255, 0.55)',
+    fontSize: Math.min(screenWidth * 0.038, 15),
+    fontWeight: '600',
   },
   videoTabBar: {
     flexDirection: 'row',

--- a/apps/pwa/src/screens/HoyScreen.web.jsx
+++ b/apps/pwa/src/screens/HoyScreen.web.jsx
@@ -353,9 +353,42 @@ const HoyScreen = () => {
     });
   }, [navigate]);
 
-  const handleBeginWorkout = useCallback(({ course, workout, sessionId }) => {
-    navigate('/warmup', { state: { course, workout, sessionId } });
-  }, [navigate]);
+  const handleBeginWorkout = useCallback(async ({ course, workout, sessionId, mode }) => {
+    // "Empezar de nuevo" (and the normal first start) → warmup then a fresh session.
+    if (mode !== 'reopen') {
+      navigate('/warmup', { state: { course, workout, sessionId } });
+      return;
+    }
+
+    // "Continuar sesión" → reopen the already-completed session. Find its saved
+    // record, reshape it into a checkpoint, and drop straight into execution
+    // (skipping warmup, like the recovery flow). On finish, the execution screen
+    // sends reopenCompletionId so the server replaces it instead of duplicating.
+    const cId = course?.courseId || course?.id;
+    if (!cId || !user?.uid) return;
+    const today = new Date().toISOString().slice(0, 10);
+    let completion = null;
+    try {
+      completion = await sessionService.getLatestCompletionForSession(user.uid, cId, sessionId, today);
+    } catch {
+      completion = null;
+    }
+    if (!completion) {
+      // Couldn't locate the completed session — fall back to a fresh start.
+      navigate('/warmup', { state: { course, workout, sessionId } });
+      return;
+    }
+    const checkpoint = sessionService.buildReopenCheckpoint(completion, workout);
+    navigate(`/course/${cId}/workout/execution`, {
+      state: {
+        course,
+        workout,
+        sessionId,
+        checkpoint,
+        reopenCompletionId: completion.completionId || completion.id,
+      },
+    });
+  }, [navigate, user?.uid]);
 
   const handleRenewCourse = useCallback((course) => {
     const id = course?.courseId || course?.id;

--- a/apps/pwa/src/screens/WorkoutExecutionScreen.js
+++ b/apps/pwa/src/screens/WorkoutExecutionScreen.js
@@ -314,15 +314,43 @@ const createStableInputHandler = (exerciseIndex, setIndex, field, updateSetData)
   };
 };
 
+// Merge in-flight input values (typed but not yet flushed to setData via blur)
+// over a setData snapshot. Used at every persistence point so a value that never
+// fired onBlur — row unmounted, app backgrounded, iOS PWA swallowed the blur — is
+// still saved instead of silently dropped.
+const mergeSetData = (base, pending) => {
+  const keys = pending ? Object.keys(pending) : [];
+  if (keys.length === 0) return base;
+  const next = { ...base };
+  keys.forEach(key => {
+    if (pending[key]) next[key] = { ...next[key], ...pending[key] };
+  });
+  return next;
+};
+
 const listInputWrapperStyle = { flex: 1, minWidth: 0 };
 // List view set input: keeps value in local state while focused and flushes to parent on blur.
 // Prevents parent setData updates on every keystroke, which was causing full re-renders and input blur.
 // Freeze on touch/pointer down (before focus) so viewport resize from keyboard doesn't trigger
 // dimension-driven re-renders that dismiss the keyboard on iOS PWA.
-const ListViewSetInputField = memo(({ exerciseIndex, setIndex, field, savedValue, updateSetData, style, placeholderText, listViewInputJustFocusedRef, restoreListViewModelScroll, freezeDimsForListInput, unfreezeDimsForListInput }) => {
+const ListViewSetInputField = memo(({ exerciseIndex, setIndex, field, savedValue, updateSetData, style, placeholderText, listViewInputJustFocusedRef, restoreListViewModelScroll, freezeDimsForListInput, unfreezeDimsForListInput, pendingInputRef }) => {
   const [localValue, setLocalValue] = useState(null);
   const isEditing = localValue !== null;
   const displayValue = isEditing ? localValue : savedValue;
+  // Mirror each keystroke into a screen-level ref synchronously (no re-render, so
+  // it can't dismiss the keyboard). Persistence points read this, so the value is
+  // safe even if onBlur never fires. Cleared once committed to setData on blur.
+  const writePending = useCallback((value) => {
+    if (!pendingInputRef) return;
+    const key = `${exerciseIndex}_${setIndex}`;
+    if (!pendingInputRef.current) pendingInputRef.current = {};
+    pendingInputRef.current[key] = { ...pendingInputRef.current[key], [field]: value };
+  }, [pendingInputRef, exerciseIndex, setIndex, field]);
+  const clearPending = useCallback(() => {
+    if (!pendingInputRef?.current) return;
+    const key = `${exerciseIndex}_${setIndex}`;
+    if (pendingInputRef.current[key]) delete pendingInputRef.current[key][field];
+  }, [pendingInputRef, exerciseIndex, setIndex, field]);
   const onPointerDown = useCallback(() => {
     if (freezeDimsForListInput) freezeDimsForListInput();
   }, [freezeDimsForListInput]);
@@ -339,14 +367,17 @@ const ListViewSetInputField = memo(({ exerciseIndex, setIndex, field, savedValue
     if (unfreezeDimsForListInput) unfreezeDimsForListInput();
     const final = localValue !== null ? localValue : savedValue;
     if (final !== savedValue) updateSetData(exerciseIndex, setIndex, field, final);
+    // Committed to setData (or unchanged) — drop the in-flight copy so it can't
+    // later shadow an edit made through another path (e.g. the set-detail modal).
+    clearPending();
     setLocalValue(null);
-  }, [unfreezeDimsForListInput, localValue, savedValue, exerciseIndex, setIndex, field, updateSetData]);
+  }, [unfreezeDimsForListInput, localValue, savedValue, exerciseIndex, setIndex, field, updateSetData, clearPending]);
   return (
     <View style={listInputWrapperStyle} onPointerDown={onPointerDown} onTouchStart={onPointerDown}>
       <TextInput
         style={style}
         value={displayValue}
-        onChangeText={(value) => setLocalValue(value)}
+        onChangeText={(value) => { setLocalValue(value); writePending(value); }}
         onFocus={onFocus}
         onBlur={onBlur}
         keyboardType="numeric"
@@ -771,6 +802,10 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
   // Set when the user voluntarily discards or successfully completes. Gates the
   // unmount checkpoint flush so it can't resurrect a just-cleared checkpoint.
   const sessionEndedRef = useRef(false);
+  // Holds set-input values typed but not yet flushed to setData on blur, keyed by
+  // `${exerciseIndex}_${setIndex}` → { field: value }. Merged into setData at every
+  // persistence point so an un-flushed weight is never lost.
+  const pendingInputRef = useRef({});
 
   // Ref for focus effect timeout tracking (must be at top level, not inside conditional)
   const focusTimeoutIdsRef = useRef([]);
@@ -1355,6 +1390,7 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
     const currentUser = user || auth.currentUser;
     if (!currentUser || !course || !workout) return null;
     const startTime = workoutStartTimeRef.current || Date.now();
+    const effectiveSetData = mergeSetData(setData, pendingInputRef.current);
     return {
       version: 1,
       userId: currentUser.uid,
@@ -1375,7 +1411,7 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
         })),
       })),
       completedSets: Object.fromEntries(
-        Object.entries(setData).filter(([, v]) =>
+        Object.entries(effectiveSetData).filter(([, v]) =>
           v && typeof v === 'object' && Object.values(v).some(val => val !== '' && val !== null && val !== undefined)
         )
       ),
@@ -2475,6 +2511,14 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
     
     return { evenGap, totalBoxWidth };
   }, [getFieldDisplayName]);
+
+  // Leave the session without discarding: persist a checkpoint (which now folds
+  // in any value typed but not yet flushed on blur) so the user can resume from
+  // Hoy / DailyWorkout. Gives a frustrated user a safe exit that isn't "discard".
+  const handleExitKeepProgress = useCallback(() => {
+    try { saveCheckpointToLocalStorage(); } catch {}
+    navigation.goBack();
+  }, [saveCheckpointToLocalStorage, navigation]);
 
   const handleDiscardWorkout = useCallback(async () => {
     // Use custom modal on web, Alert.alert on native
@@ -4261,10 +4305,13 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
   const executeEndWorkout = useCallback(async () => {
                  try {
                    setIsSavingWorkout(true);
-                   
+
                    // Get user from useAuth hook, fallback to Firebase auth.currentUser if needed
                    const currentUser = user || auth.currentUser;
-                   
+                   // Fold in any value typed but not yet flushed on blur so the final
+                   // save can't drop the last set the user was editing.
+                   const effectiveSetData = mergeSetData(setData, pendingInputRef.current);
+
                    if (currentUser?.uid && course?.courseId) {
                      // Save only exercises that have actual user data before completing
                      for (let exerciseIndex = 0; exerciseIndex < workout.exercises.length; exerciseIndex++) {
@@ -4274,7 +4321,7 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
 
                        for (let setIndex = 0; setIndex < exercise.sets.length; setIndex++) {
                          const setKey = `${exerciseIndex}_${setIndex}`;
-                         const currentSetData = setData[setKey] || {};
+                         const currentSetData = effectiveSetData[setKey] || {};
                          allSets.push(currentSetData);
                          const hasReps = currentSetData.reps && currentSetData.reps !== '' && (!isNaN(parseFloat(currentSetData.reps)) || String(currentSetData.reps).trim().toUpperCase() === 'AMRAP');
                          const hasWeight = currentSetData.weight && currentSetData.weight !== '' && !isNaN(parseFloat(currentSetData.weight));
@@ -4295,7 +4342,7 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
                       exercises: workout.exercises.map((exercise, exerciseIndex) => {
                         const setsWithData = exercise.sets.map((set, setIndex) => {
                           const key = `${exerciseIndex}_${setIndex}`;
-                          const actualSetData = setData[key] || {};
+                          const actualSetData = effectiveSetData[key] || {};
 
                           return {
                             ...set,
@@ -4332,10 +4379,10 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
                     // This catches index-alignment bugs on the resume path.
                     if (
                       workoutWithSetData.exercises.length === 0 &&
-                      Object.values(setData).some(v => v && (v.reps || v.weight || v.time || v.distance || v.duration))
+                      Object.values(effectiveSetData).some(v => v && (v.reps || v.weight || v.time || v.distance || v.duration))
                     ) {
                       logger.error('❌ completeSession aborted: setData present but all exercises filtered out', {
-                        setDataKeys: Object.keys(setData).length,
+                        setDataKeys: Object.keys(effectiveSetData).length,
                         workoutExerciseCount: workout.exercises?.length,
                       });
                       Alert.alert(
@@ -4573,11 +4620,12 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
             restoreListViewModelScroll={restoreListViewModelScroll}
             freezeDimsForListInput={freezeDimsForListInput}
             unfreezeDimsForListInput={unfreezeDimsForListInput}
+            pendingInputRef={pendingInputRef}
           />
         </View>
       );
     });
-  }, [workout, setValidationErrors, updateSetData, restoreListViewModelScroll, freezeDimsForListInput, unfreezeDimsForListInput]);
+  }, [workout, setValidationErrors, updateSetData, restoreListViewModelScroll, freezeDimsForListInput, unfreezeDimsForListInput, pendingInputRef]);
 
   // Render function for FlatList exercise items
   const renderExerciseItem = useCallback(({ item: exercise, index: exerciseIndex }) => {
@@ -5478,24 +5526,36 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
               style={styles.menuOption}
               onPress={() => {
                 setIsMenuVisible(false);
-                handleDiscardWorkout();
-              }}
-            >
-              <View style={styles.menuOptionContent}>
-                <SvgFileRemove width={20} height={20} color="#ffffff" />
-                <Text style={styles.menuOptionText}>Salir y Descartar Entrenamiento</Text>
-              </View>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.menuOptionLast}
-              onPress={() => {
-                setIsMenuVisible(false);
                 handleEndWorkout();
               }}
             >
               <View style={styles.menuOptionContent}>
                 <SvgFileUpload width={20} height={20} color="#ffffff" />
                 <Text style={styles.menuOptionText}>Guardar y Subir Entrenamiento</Text>
+              </View>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.menuOption}
+              onPress={() => {
+                setIsMenuVisible(false);
+                handleExitKeepProgress();
+              }}
+            >
+              <View style={styles.menuOptionContent}>
+                <SvgFileUpload width={20} height={20} color="#ffffff" style={{ opacity: 0.7, transform: [{ rotate: '180deg' }] }} />
+                <Text style={styles.menuOptionText}>Salir y continuar después</Text>
+              </View>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.menuOptionLast}
+              onPress={() => {
+                setIsMenuVisible(false);
+                handleDiscardWorkout();
+              }}
+            >
+              <View style={styles.menuOptionContent}>
+                <SvgFileRemove width={20} height={20} color="#ffffff" />
+                <Text style={styles.menuOptionText}>Salir y Descartar Entrenamiento</Text>
               </View>
             </TouchableOpacity>
           </View>

--- a/apps/pwa/src/screens/WorkoutExecutionScreen.js
+++ b/apps/pwa/src/screens/WorkoutExecutionScreen.js
@@ -839,7 +839,7 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
   if (servicesDuration > 500) {
   }
   
-  const { course: routeCourse, workout: initialWorkout, sessionId, checkpoint: routeCheckpointFromParams } = route.params;
+  const { course: routeCourse, workout: initialWorkout, sessionId, checkpoint: routeCheckpointFromParams, reopenCompletionId } = route.params;
   const { user } = useAuth();
   const { isMuted, toggleMute } = useVideo();
 
@@ -4349,7 +4349,7 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
                       currentUser.uid,
                       course.courseId,
                       workoutWithSetData,
-                      { plannedWorkout: workout, userNotes: sessionNotes }
+                      { plannedWorkout: workout, userNotes: sessionNotes, replacesCompletionId: reopenCompletionId || null }
                     );
                      
                      if (result) {

--- a/apps/pwa/src/screens/WorkoutExecutionScreen.web.jsx
+++ b/apps/pwa/src/screens/WorkoutExecutionScreen.web.jsx
@@ -48,6 +48,7 @@ const WorkoutExecutionScreen = () => {
       workout: location.state?.workout || null,
       sessionId: location.state?.sessionId || null,
       checkpoint: location.state?.checkpoint || null,
+      reopenCompletionId: location.state?.reopenCompletionId || null,
     }
   }), [location.state]);
 

--- a/apps/pwa/src/services/exerciseHistoryService.js
+++ b/apps/pwa/src/services/exerciseHistoryService.js
@@ -7,7 +7,7 @@ class ExerciseHistoryService {
    * Add session data to both exercise and session history.
    * All writes are handled server-side by POST /workout/complete.
    */
-  async addSessionData(userId, sessionData, plannedSnapshot = null) {
+  async addSessionData(userId, sessionData, plannedSnapshot = null, replacesCompletionId = null) {
     if (!sessionData || !sessionData.exercises || !Array.isArray(sessionData.exercises)) {
       throw new Error('Invalid session data structure');
     }
@@ -24,6 +24,9 @@ class ExerciseHistoryService {
       planned: plannedSnapshot ? {
         exercises: plannedSnapshot.exercises,
       } : undefined,
+      // Present only when re-finishing a reopened session: the server replaces
+      // this completion's footprint instead of appending a duplicate.
+      replacesCompletionId: replacesCompletionId || undefined,
     };
 
     const res = await apiClient.post('/workout/complete', body);

--- a/apps/pwa/src/services/purchaseService.js
+++ b/apps/pwa/src/services/purchaseService.js
@@ -95,7 +95,7 @@ class PurchaseService {
    * @param {string} payerEmail - Mercado Pago email from login
    * @returns {Promise<Object>} Checkout result
    */
-  async prepareSubscription(userId, courseId, payerEmail) {
+  async prepareSubscription(userId, courseId, payerEmail, surface) {
     try {
       if (!payerEmail) {
         return {
@@ -107,7 +107,11 @@ class PurchaseService {
 
       let result;
       try {
-        result = await apiClient.post('/payments/subscription', { courseId, payer_email: payerEmail });
+        result = await apiClient.post('/payments/subscription', {
+          courseId,
+          payer_email: payerEmail,
+          ...(surface ? { surface } : {}),
+        });
       } catch (error) {
         if (error.code === 'CAPACITY_FULL') {
           return {
@@ -134,6 +138,7 @@ class PurchaseService {
       return {
         success: true,
         checkoutURL: initPoint,
+        subscriptionId: result?.data?.subscription_id || null,
       };
     } catch (error) {
       logger.error('❌ [prepareSubscription] Exception:', error.message);
@@ -211,7 +216,7 @@ class PurchaseService {
   /**
    * Prepare a bundle subscription checkout. Always monthly recurring.
    */
-  async prepareBundleSubscription(bundleId, payerEmail) {
+  async prepareBundleSubscription(bundleId, payerEmail, surface) {
     try {
       try {
         analyticsService.track('program.purchase_started', {
@@ -232,6 +237,7 @@ class PurchaseService {
         result = await apiClient.post('/payments/bundle-subscription', {
           bundleId,
           payer_email: payerEmail,
+          ...(surface ? { surface } : {}),
         });
       } catch (error) {
         if (error.code === 'CONFLICT') {
@@ -245,7 +251,11 @@ class PurchaseService {
       }
       const initPoint = result?.data?.init_point;
       if (!initPoint) throw new Error('Error creating bundle subscription checkout');
-      return { success: true, checkoutURL: initPoint };
+      return {
+        success: true,
+        checkoutURL: initPoint,
+        subscriptionId: result?.data?.subscription_id || null,
+      };
     } catch (error) {
       return { success: false, error: error.message || 'Error preparing bundle subscription' };
     }

--- a/apps/pwa/src/services/sessionService.js
+++ b/apps/pwa/src/services/sessionService.js
@@ -403,6 +403,7 @@ class SessionService {
    * @param {Object} sessionData - Session/workout data with performed exercises
    * @param {Object} [options] - Optional options
    * @param {Object} [options.plannedWorkout] - Original workout template (before user merge) for planned snapshot
+   * @param {string} [options.replacesCompletionId] - When re-finishing a reopened session, the original completion id to replace instead of appending a new one
    */
   async completeSession(userId, courseId, sessionData, options = {}) {
     try {
@@ -440,8 +441,15 @@ class SessionService {
         ? this.buildPlannedSnapshot(options.plannedWorkout)
         : null;
 
-      // Submit session — server handles course progress, 1RM, streak atomically
-      const serverResult = await this.addSessionData(userId, actualSessionData, plannedSnapshot);
+      // Submit session — server handles course progress, 1RM, streak atomically.
+      // replacesCompletionId tells the server to replace a reopened session's
+      // footprint instead of appending a duplicate.
+      const serverResult = await this.addSessionData(
+        userId,
+        actualSessionData,
+        plannedSnapshot,
+        options.replacesCompletionId ?? null
+      );
       const personalRecords = serverResult?.personalRecords ?? [];
       if (serverResult?.completionId) {
         actualSessionData.completionDocId = serverResult.completionId;
@@ -629,15 +637,98 @@ class SessionService {
    * @param {Object} sessionData - Session data with exercises (performed)
    * @param {Object} [plannedSnapshot] - Optional snapshot of planned session at completion time
    */
-  async addSessionData(userId, sessionData, plannedSnapshot = null) {
+  async addSessionData(userId, sessionData, plannedSnapshot = null, replacesCompletionId = null) {
     try {
-      const result = await exerciseHistoryService.addSessionData(userId, sessionData, plannedSnapshot);
+      const result = await exerciseHistoryService.addSessionData(userId, sessionData, plannedSnapshot, replacesCompletionId);
       return result;
-      
+
     } catch (error) {
       logger.error('Error adding session data:', error);
       throw error;
     }
+  }
+
+  /**
+   * Find the most recent completion of a given program session on a given day.
+   * Used by the Hoy "Continuar sesión" flow to locate which completed session
+   * record to reopen. Sessions come back newest-first, so the first match wins.
+   * @returns {Promise<Object|null>} the sessionHistory record (with completionId) or null
+   */
+  async getLatestCompletionForSession(userId, courseId, sessionId, date) {
+    try {
+      const res = await apiClient.get('/workout/sessions', { params: { courseId, limit: 20 } });
+      const docs = res?.data ?? [];
+      // Sessions come back newest-first. Prefer a completion on the given date,
+      // but fall back to the most recent completion of this session so reopen
+      // still works when it was finished on an earlier day.
+      const sameSession = docs.filter((d) => d.sessionId === sessionId);
+      if (sameSession.length === 0) return null;
+      const onDate = date
+        ? sameSession.find((d) => (d.date || d.completedAt || '').slice(0, 10) === date)
+        : null;
+      const match = onDate || sameSession[0];
+      return { ...match, completionId: match.completionId || match.id };
+    } catch (error) {
+      logger.error('Error fetching latest completion for session:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Reshape a completed sessionHistory record into the checkpoint format the
+   * execution screen already understands, so reopening reuses the same recovery
+   * machinery. `completedSets` is keyed by the SAVED exercise order; the screen
+   * remaps it to the current program order by exerciseId.
+   * @param {Object} completion - sessionHistory record (performed exercises/sets)
+   * @param {Object} workout - the planned workout (for naming fallbacks)
+   * @returns {Object} checkpoint
+   */
+  buildReopenCheckpoint(completion, workout) {
+    const SKIP_FIELDS = new Set([
+      'id', 'order', 'notes', 'description', 'title', 'name',
+      'created_at', 'updated_at', 'createdAt', 'updatedAt',
+      'type', 'status', 'category', 'tags', 'metadata', 'plannedIntensity',
+    ]);
+    const savedExercises = Array.isArray(completion?.exercises) ? completion.exercises : [];
+    const completedSets = {};
+    const exercises = [];
+    savedExercises.forEach((ex, exIdx) => {
+      exercises.push({ exerciseId: ex.exerciseId || ex.id || null, exerciseName: ex.exerciseName || null });
+      const sets = Array.isArray(ex.sets) ? ex.sets : [];
+      sets.forEach((set, setIdx) => {
+        const fields = {};
+        Object.keys(set || {}).forEach((field) => {
+          if (SKIP_FIELDS.has(field)) return;
+          const v = set[field];
+          if (v === null || v === undefined || v === '') return;
+          fields[field] = typeof v === 'number' ? String(v) : v;
+        });
+        completedSets[`${exIdx}_${setIdx}`] = fields;
+      });
+    });
+
+    // The completion's stored duration is in SECONDS (named durationMs in storage
+    // but treated as seconds everywhere, e.g. analytics' duration_seconds). When
+    // it's absent/zero the timer simply resumes from 0 — sets still restore fully.
+    const elapsedSeconds = Math.max(0, Math.round(Number(completion?.durationMs ?? completion?.duration ?? 0) || 0));
+
+    return {
+      userId: completion?.userId ?? null,
+      sessionId: completion?.sessionId ?? null,
+      courseId: completion?.courseId ?? null,
+      sessionName: completion?.sessionName ?? workout?.name ?? workout?.title ?? null,
+      completedSets,
+      exercises,
+      currentExerciseIndex: 0,
+      currentSetIndex: 0,
+      elapsedSeconds,
+      userNotes: completion?.userNotes ?? '',
+      // Anchor the running timer to the already-elapsed time so it continues
+      // from where the session left off rather than restarting at zero.
+      startedAt: new Date(Date.now() - elapsedSeconds * 1000).toISOString(),
+      savedAt: new Date().toISOString(),
+      reopen: true,
+    };
   }
 
   /**

--- a/config/firebase/firestore.indexes.json
+++ b/config/firebase/firestore.indexes.json
@@ -382,6 +382,15 @@
         {"order": "DESCENDING", "queryScope": "COLLECTION"},
         {"order": "ASCENDING", "queryScope": "COLLECTION_GROUP"}
       ]
+    },
+    {
+      "collectionGroup": "subscriptions",
+      "fieldPath": "status",
+      "indexes": [
+        {"order": "ASCENDING", "queryScope": "COLLECTION"},
+        {"order": "DESCENDING", "queryScope": "COLLECTION"},
+        {"order": "ASCENDING", "queryScope": "COLLECTION_GROUP"}
+      ]
     }
   ]
 }

--- a/docs/superpowers/specs/2026-06-04-transparent-subscription-checkout-design.md
+++ b/docs/superpowers/specs/2026-06-04-transparent-subscription-checkout-design.md
@@ -1,0 +1,203 @@
+# Transparent Subscription Checkout (MercadoPago Bricks) — Design
+
+- **Date:** 2026-06-04
+- **Status:** Approved design, pre-implementation
+- **Scope:** Web only · subscriptions only · native frozen
+
+---
+
+## Problem
+
+Subscription checkouts break a lot. We create a MercadoPago **PreApproval** with a pre-bound `payer_email` (the user's Wake account email), `status: "pending"`, and redirect the user to MercadoPago's hosted page (`init_point`). MercadoPago **requires the email/account the user authorizes with to match that pre-bound `payer_email`**. Many users' real MercadoPago account email differs from their Wake email, so the flow dies at the end — on MercadoPago's page.
+
+A reactive "enter your MercadoPago email" recovery exists (the 409 `requireAlternateEmail` path + alt-email modal), but it only fires when MercadoPago rejects at **PreApproval creation**. The common failure happens **after redirect, on MercadoPago's hosted page**, which our code cannot intercept. That's why it's frequent despite the existing recovery.
+
+### Root cause
+The failure is intrinsic to the **redirect + MercadoPago-account-login** model. We cannot know a user's MercadoPago account email ahead of time, and we cannot force them to log into the matching account. Any fix that keeps the hosted redirect can only *reduce* failures, not eliminate them.
+
+## Decision
+
+Switch **web** subscription creation to MercadoPago's **transparent card flow**:
+
+- The **Card Payment Brick** (Bricks) renders a card form in MercadoPago's hosted iframe fields, tokenizes the card **in-browser**, and returns a single-use `card_token_id`. Card data never touches our Cloud Functions.
+- The backend creates the PreApproval with that `card_token_id` and `status: "authorized"`. No redirect, no MercadoPago login.
+- `payer_email` becomes a non-blocking label (we use the account email). **The email-match wall ceases to exist.**
+
+Locked sub-decisions:
+- **Card form:** Card Payment Brick (handles tokenization, validation, installments). **3-D Secure handling is NOT assumed** — see the 3DS go/no-go gate below; it is the first thing we prove on staging, before any UI is built.
+- **Grant path:** unchanged webhook as the single source of truth + poll of the existing `/public/checkout/status`. Authorization is synchronous, but **access timing differs by trial state** (see "Grant path & timing" below) — non-trial access can lag the first-payment webhook by up to ~1 hour.
+- **Native:** frozen — keeps the redirect + existing alt-email modal. No stopgap this phase. (Native opens the MercadoPago `init_point` in `EpaycoWebView` — a legacy-named generic webview, *not* the ePayco processor — so native still routes through the same `/payments/*` endpoints. The additive framing holds.)
+
+## Scope
+
+**In scope (web):**
+- PWA web subscription purchase (`CourseDetailScreen` + `BundleDetailScreen`).
+- Landing storefront subscription purchase (`CreatorProgramDetailScreen`).
+
+**Out of scope:**
+- One-time payments (no email-match problem; guest checkout already works).
+- Native iOS/Android (frozen; redirect flow untouched).
+- MercadoPago provider migration.
+
+## Architecture
+
+The landing storefront is web-only, so `/public/checkout/start` (subscription mode) can switch fully. The PWA endpoints are called by **both** PWA-web and PWA-native, so they must support both modes:
+
+> **`card_token_id` is a new optional field on the existing endpoints.**
+> - Present → transparent authorized flow (web).
+> - Absent → existing redirect flow, byte-for-byte unchanged (native + web fallback).
+
+This keeps the change **purely additive**. Even deployed to production, current behavior is identical until a client deliberately sends a token.
+
+Affected endpoints:
+- `/payments/subscription` — PWA, single course ([functions/src/api/routes/payments.ts](../../../functions/src/api/routes/payments.ts) ~L287)
+- `/payments/bundle-subscription` — PWA, bundles (~L543)
+- `/public/checkout/start` (subscription mode) — landing ([functions/src/api/routes/public.ts](../../../functions/src/api/routes/public.ts) ~L617)
+
+## Backend changes
+
+For each endpoint, add a `card_token_id` branch:
+
+```ts
+result = await preapproval.create({ body: {
+  payer_email: buyerEmail,            // account email — now just a label, no match required
+  card_token_id: body.card_token_id,  // NEW
+  reason, external_reference,
+  auto_recurring: { /* identical to today, incl. free_trial */ },
+  status: "authorized",               // was "pending"
+  notification_url,
+  // NEW fraud signals — see "Fraud signal" below. The hosted page collected
+  // these automatically; the transparent flow must send them explicitly.
+  ...{device_id: body.device_id},     // MP device session fingerprint from the client
+  // additional_info / payer details sent on the call for risk scoring
+}});
+```
+
+- Returns **synchronously**: `{ data: { authorized: true, subscriptionId } }` — no `init_point`.
+- The Firestore subscription doc is written exactly as today (same fields, `status: "pending"` until the webhook confirms, `free_trial_days`, `next_billing_date`, etc.).
+- **New failure mode:** card declined / 3DS failed → return **`400` with a defined code (`CARD_DECLINED`, non-retryable)** and a Spanish message the form renders inline. (Avoids `402`, which is not in the project's standard HTTP error table — CLAUDE.md lists 400/401/403/404/409/429/500/503. If we prefer `402`, add it to that table explicitly first.) No email-mismatch branch on the card path.
+- **Double-submit idempotency (new requirement):** the redirect flow dedupes recent pending rows (the CR-6 guard in `public.ts`); the synchronous authorized path has **no equivalent** and a fast double-submit or double-firing token callback could create **two authorized PreApprovals = double charge**. Add a server-side idempotency key (e.g. `userId+courseId+token`) plus disable-on-submit on the client.
+- The existing `card_token_id`-absent branch (redirect, 409 alt-email string-matching) is **left intact** for native.
+
+### Fraud signal (must-have, new)
+
+The hosted redirect page collected MercadoPago's **device session fingerprint** and ran full hosted fraud screening automatically. The transparent flow does **not** — we must replicate it or ship blind to fraud signal (which our production dig associates with a real `high_risk` rejection tail):
+
+- Load MercadoPago's **device fingerprint script** on the card page and pass the resulting **`device_id`** to the endpoint, which forwards it on `preapproval.create`.
+- Send **`additional_info` (payer)** on the authorized call for risk scoring.
+- Treat this as **in scope, not optional** — it directly affects approval rates.
+
+## Frontend changes
+
+PWA (Expo→web) and landing (Vite) are separate builds, so the card form is implemented **once per app** (same pattern, two thin integrations — not literally shared):
+
+- Load **MercadoPago.js** + the **device fingerprint script**; mount the **Card Payment Brick**, styled to match Wake.
+- **Recurring-consent disclosure (new, required):** before the user authorizes, the form must clearly disclose the **recurring nature, amount, billing frequency, and how to cancel**, and capture **explicit affirmative consent** with a stored record. Leaving MercadoPago's hosted page means we lose its consent artifact; under Colombian consumer law (Ley 1480, Estatuto del Consumidor) this disclosure + consent is a legal requirement, and it's also a trust/conversion element. This is part of frontend scope.
+- On token callback → POST with `card_token_id` (+ `device_id`) → on success, show inline confirmation, then poll `/public/checkout/status` until access lands. The poll must **degrade gracefully** for non-trial subs whose first-payment webhook lags (show "Tu pago se está procesando, te avisaremos" instead of an endless spinner — see "Grant path & timing").
+- **Retry contract (new):** MercadoPago `card_token` is **single-use and expires in ~7 days**. On a decline, the same token **cannot** be reused — the Brick must **re-tokenize** before any resubmit, or a "retry" button silently fails. Wire the retry to re-create the token.
+- **PWA web:** new `.web.jsx` card-form component used by `CourseDetailScreen` + `BundleDetailScreen` on web; native keeps `EpaycoWebView` + alt-email modal.
+- **Landing:** card form replaces the redirect in `CreatorProgramDetailScreen`; `needsAltEmail` modal removed there.
+
+### Feature flag (default OFF)
+The new web card form is gated behind a flag following the existing `?wake_debug=1` / `localStorage.WAKE_DEBUG` pattern — e.g. `?wake_card=1` / `localStorage.WAKE_CARD_CHECKOUT`. Real users keep the redirect flow until we deliberately flip it on. This is the primary runtime safety net.
+
+## Grant path & timing (verify, don't assume)
+
+Access is granted by the existing webhook (single source of truth), but timing depends on trial state — verified in [payments.ts:978](../../../functions/src/api/routes/payments.ts):
+
+- **Trial subs:** access is granted **synchronously** when the `subscription_preapproval` webhook reports `status: "authorized"` — flips within seconds. Good.
+- **Non-trial subs:** there is **no** authorized-time grant; access depends on the **first-payment webhook**, which MercadoPago may fire **up to ~1 hour after authorization**. So a non-trial user can authorize successfully and then watch the poll spin.
+
+Implications:
+- Do **not** claim "access within seconds" for non-trial. The poll must degrade gracefully (processing message + we-will-notify, not an endless spinner).
+- This is a **real unknown to validate on staging**, not a formality — confirm the actual first-payment latency for non-trial authorized PreApprovals and decide whether we need an authorized-time optimistic grant for non-trial (deferred unless the lag proves bad).
+
+## What's removed (web only)
+- Landing: `needsAltEmail` modal + retry path in `CreatorProgramDetailScreen`.
+- PWA web: `showEmailModal` path in `CourseDetailScreen` (kept for native).
+- Backend 409 string-matching: **kept** (native), never hit on the card path.
+
+## Recurring logic preservation (must-not-break)
+
+The recurring engine is entirely MercadoPago's, driven by the PreApproval's `auto_recurring` config — **identical in both flows**. The resulting authorized PreApproval is indistinguishable to MercadoPago and to our webhook from a redirect-created one. Only `status` and `card_token_id` differ at creation.
+
+**Untouched:**
+- All webhook handlers (`subscription_preapproval`, payment events): `external_reference → userId` matching, access grants, trial→paid transition, `processed_payments` idempotency.
+- `auto_recurring` shape, free-trial config, 30-day rolling access, monthly-drop gate, cancellation.
+
+**Proven by:** additive code (redirect path unchanged) + staging regression test confirming a card-token subscription produces the same subscription doc, the same webhook events, and the same access grant as a redirect one — and that the redirect path still works.
+
+## Security / PCI
+
+Card data is tokenized in MercadoPago's hosted iframe fields and never reaches our Cloud Functions. PCI scope stays minimal (effectively **SAQ A**, self-attestation — no third-party audit). We take on client-side flow ownership (form, declines, and — pending the Phase 0 gate — 3DS results). MercadoPago.js must be loaded from MercadoPago's CDN (never self-hosted) to preserve this.
+
+## Money flow (unchanged)
+
+- **Charge:** first charge processes immediately and synchronously on authorization (or after the trial), same as today.
+- **Settlement/payout:** a property of the MercadoPago account, not the integration. Same account, same release schedule. **No change.**
+- **Customer statements:** the validation micro-charge + reversal (and the first charge) can appear on the customer's card statement — pre-empt the "¿por qué me cobraron?" support ticket with clear copy on the confirmation screen.
+
+## Prerequisites & account state (verify, don't assume)
+
+1. **Card processing via API enabled** (Colombia) — confirm in the MercadoPago dashboard. The redirect flow already processes cards on this account, so likely already on; 2-minute check.
+2. **Seller-account maturity** — our production `/users/me` dig found the MercadoPago account is `mercadopago_account_type: personal`, `user_type: eventual`, `required_action: simple_registration`, `billing.allow: false` (address pending). This immaturity plausibly drives the observed `high_risk` rejections and could depress the authorized-card flow's approval rate. **Complete account verification in parallel** — it's independent of the build and possibly the cheapest approval-rate win available.
+
+## Isolation & rollout strategy
+
+Three independent safety layers:
+
+1. **Code isolation:** dedicated branch in a **git worktree**; `main` stays clean; nothing lands on `main` until proven.
+2. **Runtime isolation:** backend additive (`card_token_id` optional) + web UI behind a default-OFF feature flag. Production behavior unchanged even after deploy until we flip the flag.
+3. **Payment isolation:** test on the **wake-staging** Firebase project with **MercadoPago TEST credentials** (test access token + test cards simulating approved / declined / 3DS). Production project (`wolf-20b8b`) is never touched until verified. (See `reference_staging_runbook.md`.)
+
+## Phase 0 — 3-D Secure go/no-go gate (FIRST task, blocking)
+
+Before building any UI, prove whether a **3DS challenge can be escalated and completed** when the card token is consumed by `preapproval.create` with `status: "authorized"`.
+
+### Research finding (2026-06-05) — strong NO-GO signal, empirical test still required
+
+Two independent research passes (official docs + SDK source + community) converged:
+
+- **The MercadoPago Node SDK's `PreApprovalRequest` type has NO 3DS fields.** Its complete body is `auto_recurring`, `back_url`, `card_token_id`, `external_reference`, `payer_email`, `preapproval_plan_id`, `reason`, `status` — no `three_d_secure_mode`, no challenge/`action_required`/`pending_challenge`. (`mercadopago/sdk-nodejs`, `src/clients/preApproval/commonTypes.ts`.)
+- **3DS is documented only on `POST /v1/payments`** (Checkout API / Bricks), using params (`three_d_secure_mode`, `capture`, `binary_mode`) that **don't exist on `/preapproval`**. The challenge response (`status: pending`, `status_detail: pending_challenge`, `three_ds_info.external_resource_url`) is a payments-only surface.
+- The subscription `authorized` flow validates the card via an automatic **minimum-amount validation charge**; subscription rejection handling is documented as `status_detail` reasons (e.g. `cc_rejected_high_risk`) with a 4-attempt recycle — **not** a recoverable challenge. Inference: a 3DS-mandating card likely returns `cc_rejected_*`, not a completable challenge.
+- The most-referenced LATAM community example (goncy) builds subscriptions with the **hosted redirect** (`status: pending` + `init_point`), sidestepping transparent 3DS entirely.
+
+Both passes stress this is **inference from silence** — no source explicitly says "preapproval can't do 3DS." So we still run the empirical test (harness in `/poc`), but expectations should be set to **likely NO-GO**.
+
+### The gate
+
+- **Go:** the validation charge with a 3DS-forcing test card either authorizes (frictionless) or returns a completable challenge → proceed with the full build.
+- **No-go (expected):** the 3DS-forcing card rejects (`cc_rejected_*`) with no challenge path → the clean transparent approach is not viable for 3DS-mandating Colombian issuers. Move to the fallback decision below.
+
+### If NO-GO — fallback options (each has a real cost; decide deliberately)
+
+1. **Hosted redirect, kept** — `status: pending` + `init_point`; MercadoPago owns 3DS. **But this reintroduces the original email-match problem** we set out to kill. Net: no progress on the core issue.
+2. **`/v1/payments` (3DS-capable) + self-managed recurrence** — authenticate the first charge via Bricks (which *does* support the 3DS challenge), then run recurrence ourselves by storing the card (Customer + Cards API) and charging monthly via our own scheduler. **Eliminates the email problem AND keeps 3DS — but we take over recurring billing** (a cron charging saved cards, dunning, retries), losing the "recurrence is MercadoPago's job" guarantee. Significantly larger and riskier.
+3. **Provider reconsideration** — out of scope here, but CLAUDE.md already notes MercadoPago is slated for future replacement; a NO-GO is a data point for that timeline.
+
+This gate decides whether the whole approach is viable, and if not, which fallback we accept.
+
+## Testing matrix (staging, MP test cards)
+
+- Approved card → authorized → webhook → access granted.
+- Declined card → inline Spanish error, no PreApproval orphaned.
+- 3-D Secure challenge card → Bricks challenge → success.
+- Subscription **with** free trial → no immediate charge, trial access granted, next-charge scheduled.
+- Subscription **without** trial → immediate first charge.
+- Bundle subscription path.
+- Landing path + PWA web path.
+- **Double-submit:** rapid resubmit / double-firing token callback creates exactly **one** authorized PreApproval (idempotency guard holds).
+- **Retry:** after a decline, retry re-tokenizes (single-use token not reused) and succeeds.
+- **Consent:** the recurring-disclosure consent record is stored on authorization.
+- **Fraud signal:** `device_id` + `additional_info` reach `preapproval.create`; compare approval/`high_risk` rates vs the redirect baseline.
+- **Regression:** redirect path (`card_token_id` absent) still works unchanged.
+- Confirm `auto_recurring` set identically to the redirect flow; confirm subscription doc + webhook events + grant match.
+
+## Open questions / risks
+
+- **3-D Secure on the preapproval path — the #1 risk.** Resolved by the Phase 0 go/no-go gate above; not assumed handled. (Resolves the earlier locked-vs-open contradiction: 3DS is *unproven* until Phase 0 passes.)
+- **Non-trial first-payment latency** — validate the real lag on staging (see "Grant path & timing"); decide if an authorized-time optimistic grant is needed for non-trial.
+- **Seller-account maturity** — pursue verification in parallel (see Prerequisites); may be the largest approval-rate lever.
+- MercadoPago account card-API enablement — verify before staging test.
+- Exact synchronous response contract for the confirmation screen (success copy + poll timing + processing-fallback copy) — finalize during implementation.

--- a/docs/superpowers/specs/2026-06-05-proactive-subscription-email-design.md
+++ b/docs/superpowers/specs/2026-06-05-proactive-subscription-email-design.md
@@ -1,0 +1,70 @@
+# Proactive Subscription Email + Funnel Logging — Design (minimal build)
+
+- **Date:** 2026-06-05
+- **Status:** Implemented on branch `feat/proactive-subscription-email`; pending staging test + deploy
+- **Relationship:** Near-term mitigation. The full fix (transparent card form) is deferred pending the 3DS gate — see `2026-06-04-transparent-subscription-checkout-design.md`.
+
+## Goal
+
+Reduce subscription-checkout failures caused by the MercadoPago email/account mismatch, and instrument the funnel so that in ~2 days we can measure where it still breaks.
+
+This does **not** eliminate the problem (the redirect still requires logging into a matching MercadoPago account) — it mitigates it by setting the right `payer_email` up front and telling the user which email to use.
+
+## Scope
+
+- **In:** proactive email step + funnel logging on **all three** subscription surfaces — PWA web (`CourseDetailScreen`, `BundleDetailScreen`), PWA native (same screens, RN modal), landing storefront (`CreatorProgramDetailScreen`).
+- **Out:** one-time payments; the card-token/Bricks flow; any change to recurring billing, webhooks, or access grants.
+
+## UX — one-tap confirm
+
+Before initiating the subscription redirect (replacing the current *reactive* alt-email modal with a *proactive* step):
+
+- Show the user's email prominently.
+- Primary action: **"Continuar con este correo"** (one tap → proceeds with that email).
+- Secondary action: **"Usar otro correo de Mercado Pago"** → reveals an email input.
+- Instruction copy (always visible): **"Usa este mismo correo al iniciar sesión en Mercado Pago para completar tu suscripción."**
+- The chosen email is sent as `payer_email` to the existing endpoints. No backend logic change beyond logging.
+- The existing reactive 409 `requireAlternateEmail` path stays as a safety net (if MP still rejects at creation, we re-prompt).
+
+Copy must follow Wake rules: Spanish, no emojis, no banned negation/contrast patterns.
+
+## Data flow (unchanged except email source)
+
+`email step → payerEmail → /payments/subscription | /payments/bundle-subscription | /public/checkout/start` → existing PreApproval creation → redirect → existing webhook → existing access grant. Nothing downstream changes.
+
+## Observability contract (the point of this build)
+
+One correlation id ties the funnel together: the **`subscriptionId`** (MP PreApproval id) where available, and the **`external_reference`** (`v1|{userId}|{courseId}|sub`) everywhere it isn't yet.
+
+### Client (PWA `logger` + PostHog `analyticsService`; landing logger)
+- `subscription.email_step.shown` — `{ courseId, surface }`
+- `subscription.email_step.choice` — `{ courseId, surface, choice: "account" | "custom", emailsDiffer: boolean }`
+- `subscription.checkout.redirected` — `{ courseId, surface, subscriptionId }`
+- `subscription.checkout.returned` — `{ courseId, surface }` (fired on the post-payment / status screen)
+
+Emails are never logged raw — only `emailsDiffer` and a redacted form.
+
+### Backend (`functions.logger`, structured)
+- On creation attempt: `subscription.create.attempt` — `{ userId, courseId, emailType: "account" | "custom", payerEmail: redacted, surface }`
+- On success: `subscription.create.ok` — `{ userId, courseId, subscriptionId, emailType }`
+- On MP failure: `subscription.create.fail` — `{ userId, courseId, emailType, mpStatus, mpMessage }` (extend the existing alt-email catch so we capture the MP error string/status, not just the alt-email branch).
+- Webhook transition: `subscription.webhook.status` — `{ subscriptionId, userId, courseId, from, to, trialDays }` logged on every `subscription_preapproval` status change, especially the `pending → authorized` one.
+
+### The key derived metric
+Subscriptions logged at `create.ok` (status `pending`) that **never** log a `webhook.status … to: "authorized"` within ~30 min ≈ failed/abandoned on MercadoPago's page. That count, split by `emailType`, is the verification: did sending the right email up front reduce the `pending`-stranded rate?
+
+## What's explicitly NOT changing
+- PreApproval `auto_recurring`, trials, `external_reference` format.
+- Webhook matching, access grants, idempotency, `processed_payments`.
+- One-time payment flow.
+
+## Rollout & safety
+- Purely additive (new UI step + log lines). No schema changes.
+- Test on **wake-staging** first (subscription create + webhook logs appear; redirect still works), then deploy to production with explicit confirmation (wolf-20b8b is production).
+- No feature flag: this is a strict improvement over the current reactive flow and low-risk. (If preferred, it can be flag-gated — call it out before deploy.)
+
+## Verification plan (run in ~2 days)
+1. PostHog: funnel `email_step.shown → choice → redirected → returned`, split by `choice`.
+2. Functions logs: ratio of `create.ok` to `webhook … authorized`, split by `emailType` — the stranded-at-pending rate.
+3. `create.fail` grouped by `mpMessage`/`mpStatus` — what MercadoPago errors still occur and how often.
+4. Decision input: if `custom`-email choosers strand far less than `account`-email choosers, the mitigation works; if everyone still strands at similar rates, escalate to the card-form / self-managed-recurrence decision.

--- a/functions/lib/landing-index.html
+++ b/functions/lib/landing-index.html
@@ -24,7 +24,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-WBnouSy-.js"></script>
+    <script type="module" crossorigin src="/assets/index-C2lx5T1-.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D_9PU5bc.css">
   </head>
   <body>

--- a/functions/src/api/routes/payments.ts
+++ b/functions/src/api/routes/payments.ts
@@ -48,6 +48,42 @@ function pickRecipientEmail(
   return null;
 }
 
+// ── Checkout observability ────────────────────────────────────────────────
+// Full-fidelity logging so any subscription checkout can be reconstructed end
+// to end from Cloud Logging. Every step emits a structured entry under
+// `checkout.<step>` tagged with `flow:"checkout"` and a correlation id
+// (subscriptionId / external_reference). MercadoPago request + response
+// payloads are logged VERBATIM under `mp` — they carry no card data (neither
+// the redirect nor the transparent flow exposes a PAN to us) and no secrets
+// (access token / webhook secret never appear in MP payloads). The buyer email
+// IS present in MP payloads and in `payerEmail`/`accountEmail` fields: this is
+// intentional — the whole investigation is an account-vs-payer email mismatch,
+// so the addresses are the signal. Keep these logs access-controlled.
+function logCheckout(step: string, data: Record<string, unknown>): void {
+  functions.logger.info(`checkout.${step}`, {flow: "checkout", step, ...data});
+}
+
+// Pull a usable {status, message, raw} out of whatever MP threw. The SDK throws
+// plain objects ({message, status, cause}) as often as Error instances.
+function describeMpError(error: unknown): {
+  mpStatus: number | string | null;
+  mpMessage: string;
+  mpRaw: unknown;
+} {
+  if (error instanceof Error) {
+    return {mpStatus: null, mpMessage: error.message, mpRaw: {name: error.name, message: error.message}};
+  }
+  if (error && typeof error === "object") {
+    const o = error as {message?: unknown; status?: unknown; cause?: unknown; error?: unknown};
+    return {
+      mpStatus: (typeof o.status === "number" || typeof o.status === "string") ? o.status : null,
+      mpMessage: typeof o.message === "string" ? o.message : JSON.stringify(o),
+      mpRaw: o,
+    };
+  }
+  return {mpStatus: null, mpMessage: String(error), mpRaw: String(error)};
+}
+
 // MercadoPago redirects the buyer back to one of these URLs after checkout.
 // We derive the host from the caller's Origin header when it's in the trusted
 // allowlist (so staging redirects to staging, custom-domain redirects to the
@@ -288,10 +324,11 @@ router.post("/payments/subscription", async (req, res) => {
   const auth = await validateAuth(req);
   await checkRateLimit(auth.userId, 200, "rate_limit_first_party");
 
-  const body = validateBody<{ courseId: string; payer_email: string }>(
-    {courseId: "string", payer_email: "string"},
+  const body = validateBody<{ courseId: string; payer_email: string; surface?: string }>(
+    {courseId: "string", payer_email: "string", surface: "optional_string"},
     req.body
   );
+  const surface = typeof body.surface === "string" ? body.surface : "unknown";
 
   if (!COURSE_ID_RE.test(body.courseId)) {
     throw new WakeApiServerError("VALIDATION_ERROR", 400, "courseId inválido", "courseId");
@@ -352,6 +389,16 @@ router.post("/payments/subscription", async (req, res) => {
     throw new WakeApiServerError("NOT_FOUND", 404, "Usuario no encontrado");
   }
 
+  // Classify the email the client chose so we can later compare strand-rates of
+  // "account" vs "custom" choosers. Account email comes from the verified user
+  // doc; payer_email is whatever the proactive email step sent.
+  const accountEmail =
+    typeof userDoc.data()?.email === "string" ?
+      (userDoc.data()?.email as string).trim().toLowerCase() :
+      null;
+  const emailType: "account" | "custom" =
+    accountEmail && accountEmail === body.payer_email ? "account" : "custom";
+
   const client = getMPClient();
   const preapproval = new PreApproval(client);
   const startDate = new Date(Date.now() + 5 * 60 * 1000);
@@ -371,6 +418,19 @@ router.post("/payments/subscription", async (req, res) => {
   // Without this, MP falls back to the account-level URL configured in the
   // dashboard — silently dropping webhooks if that URL is wrong/missing.
   const notificationUrl = resolveWebhookUrl();
+
+  logCheckout("subscription.create.attempt", {
+    userId: auth.userId,
+    courseId: body.courseId,
+    externalReference: externalRef,
+    surface,
+    emailType,
+    payerEmail: body.payer_email,
+    accountEmail,
+    monthlyPrice,
+    trialDays,
+    deliveryType: course.deliveryType ?? null,
+  });
 
   let result;
   try {
@@ -402,22 +462,27 @@ router.post("/payments/subscription", async (req, res) => {
       },
     });
   } catch (error: unknown) {
-    // MP SDK throws plain objects ({message, status}), not Error instances —
-    // pull .message off the object directly so the alt-email patterns still match.
-    let rawMsg: string;
-    if (error instanceof Error) {
-      rawMsg = error.message;
-    } else if (error && typeof error === "object" && typeof (error as {message?: unknown}).message === "string") {
-      rawMsg = (error as {message: string}).message;
-    } else {
-      rawMsg = String(error);
-    }
-    const msg = rawMsg.toLowerCase();
+    // MP SDK throws plain objects ({message, status}), not Error instances.
+    const {mpStatus, mpMessage, mpRaw} = describeMpError(error);
+    const msg = mpMessage.toLowerCase();
     const needsAltEmail =
       msg.includes("cannot operate between different") ||
       msg.includes("payer_email") ||
       msg.includes("belongs to another user") ||
       msg.includes("must belong to this site");
+
+    logCheckout("subscription.create.fail", {
+      userId: auth.userId,
+      courseId: body.courseId,
+      externalReference: externalRef,
+      surface,
+      emailType,
+      payerEmail: body.payer_email,
+      needsAltEmail,
+      mpStatus,
+      mpMessage,
+      mp: mpRaw,
+    });
 
     if (needsAltEmail) {
       res.status(409).json({
@@ -428,6 +493,16 @@ router.post("/payments/subscription", async (req, res) => {
     }
     throw error;
   }
+
+  logCheckout("subscription.create.mp_response", {
+    userId: auth.userId,
+    courseId: body.courseId,
+    externalReference: externalRef,
+    subscriptionId: result.id ?? null,
+    surface,
+    emailType,
+    mp: result,
+  });
 
   if (!result.init_point || !result.id) {
     throw new WakeApiServerError("INTERNAL_ERROR", 500, "No se pudo crear el enlace de pago");
@@ -470,6 +545,18 @@ router.post("/payments/subscription", async (req, res) => {
       created_at: FieldValue.serverTimestamp(),
       updated_at: FieldValue.serverTimestamp(),
     }, {merge: true});
+
+  logCheckout("subscription.create.ok", {
+    userId: auth.userId,
+    courseId: body.courseId,
+    externalReference: externalRef,
+    subscriptionId: result.id,
+    surface,
+    emailType,
+    status: result.status ?? null,
+    trialDays,
+    nextBillingDate,
+  });
 
   res.json({data: {init_point: result.init_point, subscription_id: result.id, free_trial_days: trialDays}});
 });
@@ -547,10 +634,13 @@ router.post("/payments/bundle-subscription", async (req, res) => {
   const body = validateBody<{
     bundleId: string;
     payer_email: string;
+    surface?: string;
   }>({
     bundleId: "string",
     payer_email: "string",
+    surface: "optional_string",
   }, req.body);
+  const surface = typeof body.surface === "string" ? body.surface : "unknown";
 
   if (!COURSE_ID_RE.test(body.bundleId)) {
     throw new WakeApiServerError("VALIDATION_ERROR", 400, "bundleId inválido", "bundleId");
@@ -591,6 +681,25 @@ router.post("/payments/bundle-subscription", async (req, res) => {
   const frequencyType = "months";
   const frequency = 1;
 
+  const accountEmail =
+    typeof userDoc.data()?.email === "string" ?
+      (userDoc.data()?.email as string).trim().toLowerCase() :
+      null;
+  const emailType: "account" | "custom" =
+    accountEmail && accountEmail === body.payer_email ? "account" : "custom";
+
+  logCheckout("subscription.create.attempt", {
+    userId: auth.userId,
+    bundleId: body.bundleId,
+    externalReference: externalRef,
+    kind: "bundle",
+    surface,
+    emailType,
+    payerEmail: body.payer_email,
+    accountEmail,
+    monthlyPrice: price,
+  });
+
   let result;
   try {
     result = await preapproval.create({
@@ -615,22 +724,27 @@ router.post("/payments/bundle-subscription", async (req, res) => {
       },
     });
   } catch (error: unknown) {
-    // MP SDK throws plain objects ({message, status}), not Error instances —
-    // pull .message off the object directly so the alt-email patterns still match.
-    let rawMsg: string;
-    if (error instanceof Error) {
-      rawMsg = error.message;
-    } else if (error && typeof error === "object" && typeof (error as {message?: unknown}).message === "string") {
-      rawMsg = (error as {message: string}).message;
-    } else {
-      rawMsg = String(error);
-    }
-    const msg = rawMsg.toLowerCase();
+    const {mpStatus, mpMessage, mpRaw} = describeMpError(error);
+    const msg = mpMessage.toLowerCase();
     const needsAltEmail =
       msg.includes("cannot operate between different") ||
       msg.includes("payer_email") ||
       msg.includes("belongs to another user") ||
       msg.includes("must belong to this site");
+
+    logCheckout("subscription.create.fail", {
+      userId: auth.userId,
+      bundleId: body.bundleId,
+      externalReference: externalRef,
+      kind: "bundle",
+      surface,
+      emailType,
+      payerEmail: body.payer_email,
+      needsAltEmail,
+      mpStatus,
+      mpMessage,
+      mp: mpRaw,
+    });
 
     if (needsAltEmail) {
       res.status(409).json({
@@ -683,6 +797,19 @@ router.post("/payments/bundle-subscription", async (req, res) => {
       created_at: FieldValue.serverTimestamp(),
       updated_at: FieldValue.serverTimestamp(),
     }, {merge: true});
+
+  logCheckout("subscription.create.ok", {
+    userId: auth.userId,
+    bundleId: body.bundleId,
+    externalReference: externalRef,
+    subscriptionId: result.id,
+    kind: "bundle",
+    surface,
+    emailType,
+    status: result.status ?? null,
+    nextBillingDate,
+    mp: result,
+  });
 
   res.json({data: {init_point: result.init_point, subscription_id: result.id}});
 });
@@ -843,6 +970,18 @@ router.post("/payments/webhook", async (req: Request, res) => {
   const webhookType = req.body?.type;
   const webhookAction = req.body?.action;
 
+  // Full raw capture of every signature-valid webhook MercadoPago sends, so a
+  // checkout can be reconstructed from logs. Correlation id is the MP resource
+  // id in data.id (a preapproval or payment id depending on type).
+  logCheckout("webhook.received", {
+    webhookType,
+    webhookAction,
+    dataId: req.body?.data?.id ?? null,
+    liveMode: req.body?.live_mode ?? null,
+    query: req.query ?? null,
+    mp: req.body,
+  });
+
   // ── subscription_preapproval (status updates only) ──
   if (webhookType === "subscription_preapproval") {
     const preapprovalId = req.body?.data?.id;
@@ -855,6 +994,13 @@ router.post("/payments/webhook", async (req: Request, res) => {
       const preapproval = new PreApproval(client);
       const preapprovalData = await preapproval.get({id: preapprovalId}) as unknown as MercadoPagoPreapproval;
       const externalReference = preapprovalData?.external_reference;
+      logCheckout("webhook.preapproval.fetched", {
+        preapprovalId,
+        externalReference: externalReference ?? null,
+        mpStatus: preapprovalData?.status ?? null,
+        payerEmail: preapprovalData?.payer_email ?? null,
+        mp: preapprovalData,
+      });
       if (!externalReference) {
         res.status(200).send("OK");
         return;
@@ -943,6 +1089,17 @@ router.post("/payments/webhook", async (req: Request, res) => {
         res.status(200).send("OK");
         return;
       }
+
+      logCheckout("webhook.preapproval.status", {
+        subscriptionId: preapprovalId,
+        userId: parsed.userId,
+        courseId: parsed.courseId ?? null,
+        bundleId: parsed.bundleId ?? null,
+        from: existingSubData.status ?? null,
+        to: preapprovalData?.status ?? null,
+        payerEmail: preapprovalData?.payer_email ?? null,
+        trialDays: Number(existingSubData.free_trial_days) || 0,
+      });
 
       await subRef.set(updateData, {merge: true});
 
@@ -1139,6 +1296,7 @@ router.post("/payments/webhook", async (req: Request, res) => {
   // Fetch payment from MercadoPago
   interface MercadoPagoPaymentData {
     status?: string;
+    status_detail?: string;
     external_reference?: string;
     subscription_id?: string;
     preapproval_id?: string;
@@ -1146,6 +1304,7 @@ router.post("/payments/webhook", async (req: Request, res) => {
     date_created?: string;
     transaction_amount?: number;
     currency_id?: string;
+    payer?: { email?: string };
     preapproval?: { id?: string; external_reference?: string };
     payment?: { status?: string };
   }
@@ -1173,6 +1332,14 @@ router.post("/payments/webhook", async (req: Request, res) => {
       const client = getMPClient();
       const payment = new Payment(client);
       paymentData = (await payment.get({id: paymentId}) as MercadoPagoPaymentData) || {};
+      logCheckout("webhook.payment.fetched", {
+        paymentId,
+        externalReference: paymentData?.external_reference ?? null,
+        mpStatus: paymentData?.status ?? null,
+        statusDetail: paymentData?.status_detail ?? null,
+        payerEmail: paymentData?.payer?.email ?? null,
+        mp: paymentData,
+      });
     }
   } catch (apiError: unknown) {
     const errType = classifyError(apiError);

--- a/functions/src/api/routes/public.ts
+++ b/functions/src/api/routes/public.ts
@@ -412,6 +412,13 @@ function truncateMpTitle(raw: string | undefined, fallback: string): string {
   return value.length > 200 ? value.slice(0, 197) + "…" : value;
 }
 
+// Mirror of payments.ts logCheckout: full-fidelity checkout-step logging under
+// `checkout.<step>` so storefront subscriptions can also be reconstructed from
+// Cloud Logging. MP payloads are logged verbatim (no card data, no secrets).
+function logCheckout(step: string, data: Record<string, unknown>): void {
+  functions.logger.info(`checkout.${step}`, {flow: "checkout", step, ...data});
+}
+
 router.post("/public/checkout/start", async (req, res) => {
   const auth = await validateAuth(req);
   await checkRateLimit(auth.userId, 30, "rate_limit_first_party");
@@ -421,6 +428,7 @@ router.post("/public/checkout/start", async (req, res) => {
     courseId: string;
     mode: "one_time" | "subscription";
     payerEmail?: string;
+    surface?: string;
   }>(
     {
       username: "string",
@@ -429,9 +437,11 @@ router.post("/public/checkout/start", async (req, res) => {
       // CR-5: must be declared in the schema or validateBody strips it,
       // breaking the alternate-email retry flow.
       payerEmail: "optional_string",
+      surface: "optional_string",
     },
     req.body
   );
+  const surface = typeof body.surface === "string" ? body.surface : "storefront";
 
   const username = (body.username || "").toLowerCase().trim();
   if (!USERNAME_RE.test(username)) {
@@ -679,9 +689,22 @@ router.post("/public/checkout/start", async (req, res) => {
   }
 
   const externalRef = buildExternalReference(auth.userId, body.courseId, "sub");
+  const emailType: "account" | "custom" =
+    payerEmailRaw === buyerEmail ? "account" : "custom";
   const client = getMpClient();
   const preapproval = new PreApproval(client);
   const startDate = new Date(Date.now() + 5 * 60 * 1000);
+
+  logCheckout("subscription.create.attempt", {
+    userId: auth.userId,
+    courseId: body.courseId,
+    externalReference: externalRef,
+    surface,
+    emailType,
+    payerEmail: payerEmailRaw,
+    accountEmail: buyerEmail,
+    monthlyPrice,
+  });
 
   let result;
   try {
@@ -702,12 +725,25 @@ router.post("/public/checkout/start", async (req, res) => {
       },
     });
   } catch (error: unknown) {
-    const msg = (error instanceof Error ? error.message : String(error)).toLowerCase();
+    const rawMsg = error instanceof Error ? error.message : String(error);
+    const msg = rawMsg.toLowerCase();
     const needsAltEmail =
       msg.includes("cannot operate between different") ||
       msg.includes("payer_email") ||
       msg.includes("belongs to another user") ||
       msg.includes("must belong to this site");
+
+    logCheckout("subscription.create.fail", {
+      userId: auth.userId,
+      courseId: body.courseId,
+      externalReference: externalRef,
+      surface,
+      emailType,
+      payerEmail: payerEmailRaw,
+      needsAltEmail,
+      mpMessage: rawMsg,
+      mp: error instanceof Error ? {name: error.name, message: error.message} : error,
+    });
 
     if (needsAltEmail) {
       res.status(409).json({
@@ -778,6 +814,18 @@ router.post("/public/checkout/start", async (req, res) => {
       created_at: FieldValue.serverTimestamp(),
       updated_at: FieldValue.serverTimestamp(),
     }, {merge: true});
+
+  logCheckout("subscription.create.ok", {
+    userId: auth.userId,
+    courseId: body.courseId,
+    externalReference: externalRef,
+    subscriptionId: result.id,
+    surface,
+    emailType,
+    status: result.status ?? null,
+    nextBillingDate,
+    mp: result,
+  });
 
   res.json({
     data: {

--- a/functions/src/api/routes/workout.ts
+++ b/functions/src/api/routes/workout.ts
@@ -159,6 +159,78 @@ function calculate1RM(weight: number, reps: number, intensity: number | null): n
   return numerator / denominator;
 }
 
+// History key shape: ${libraryId}_${libraryExerciseId} — keys to the *library's*
+// stable exercise id (the value of primary[libId] post-migration), NOT the session-
+// exercise doc id. Returns null when neither an explicit key nor primary[libId] is
+// available; callers skip the history write rather than persist a wrong-shape key.
+function deriveExerciseKey(ex: Record<string, unknown>): string | null {
+  if (typeof ex.exerciseKey === "string" && ex.exerciseKey) return ex.exerciseKey;
+  const primary = ex.primary as Record<string, string> | undefined;
+  const libId = (ex.libraryId as string | undefined) ?? (primary ? Object.keys(primary)[0] : null);
+  const libraryExId = libId && primary ? primary[libId] : null;
+  if (libId && libraryExId) return `${libId}_${libraryExId}`;
+  return null;
+}
+
+// Best estimated 1RM across a set list, plus the set that produced it.
+function computeBest1RM(
+  sets: Array<Record<string, unknown>>
+): { estimate: number; bestSet: { weight: number; reps: number; intensity: string | null } | null } {
+  let estimate = 0;
+  let bestSet: { weight: number; reps: number; intensity: string | null } | null = null;
+  for (const set of sets) {
+    const weight = Number(set.weight) || 0;
+    const reps = Number(set.reps) || 0;
+    if (weight <= 0 || reps <= 0) continue;
+    const intensity =
+      parseReportedIntensity(set.intensity as string) ??
+      parsePlannedIntensity(set.plannedIntensity as string) ??
+      null;
+    const est = calculate1RM(weight, reps, intensity);
+    if (est > estimate) {
+      estimate = est;
+      bestSet = {weight, reps, intensity: (set.intensity as string) ?? null};
+    }
+  }
+  return {estimate, bestSet};
+}
+
+// Heaviest set in a list (matches the prod lastPerformance.bestSet rule).
+function bestSetByWeight(
+  sets: Array<Record<string, unknown>>
+): Record<string, unknown> | null {
+  if (!sets.length) return null;
+  return sets.reduce((best, s) =>
+    (parseFloat(String(s.weight ?? 0)) > parseFloat(String(best.weight ?? 0)) ? s : best), sets[0]);
+}
+
+// Best estimated 1RM across a history `sessions` array, excluding one session —
+// used on reopen so a re-finish's PR check compares against the user's OTHER
+// sessions for that exercise, not against the session being replaced.
+function bestEstimateFromSessions(
+  sessions: Array<{ sessionId?: string; sets?: Array<Record<string, unknown>> }>,
+  excludeSessionId: string
+): number {
+  let best = 0;
+  for (const s of sessions) {
+    if (s.sessionId === excludeSessionId) continue;
+    const {estimate} = computeBest1RM(s.sets ?? []);
+    if (estimate > best) best = estimate;
+  }
+  return best;
+}
+
+// Most-recent session in a history array (latest date; ties resolved by array
+// order, since arrayUnion appends — later index is the more recent completion).
+function mostRecentSession<T extends { date?: string }>(sessions: T[]): T | null {
+  if (!sessions.length) return null;
+  let best = sessions[0];
+  for (const s of sessions) {
+    if ((s.date ?? "") >= (best.date ?? "")) best = s;
+  }
+  return best;
+}
+
 // ─── Week helpers (must match creator.ts and client-side getMondayWeek) ──────
 function getMondayWeek(date: Date = new Date()): string {
   const d = new Date(date);
@@ -1117,6 +1189,10 @@ router.get("/workout/daily", async (req, res) => {
       hasSession: true,
       isRestDay: false,
       emptyReason: null,
+      // True when the session being returned has already been completed (lifetime,
+      // for this course). Lets the Hoy card offer "Continuar sesión" (reopen) vs
+      // "Empezar de nuevo" instead of a plain start.
+      todaySessionAlreadyCompleted: completedSessionIds.has(targetSessionId),
       session: {
         sessionId: targetSessionId,
         moduleId: targetModuleId,
@@ -1450,6 +1526,7 @@ router.post("/workout/complete", async (req, res) => {
     plannedSnapshot?: unknown;
     courseName?: string;
     sessionName?: string;
+    replacesCompletionId?: string;
   }>(
     {
       courseId: "string",
@@ -1461,6 +1538,7 @@ router.post("/workout/complete", async (req, res) => {
       plannedSnapshot: "optional_object",
       courseName: "optional_string",
       sessionName: "optional_string",
+      replacesCompletionId: "optional_string",
     },
     raw,
     {maxArrayLength: 50}
@@ -1492,24 +1570,76 @@ router.post("/workout/complete", async (req, res) => {
     }
   }
 
-  // Pre-fetch existing PRs for all exercises to compare.
-  // History key shape: ${libraryId}_${libraryExerciseId} — keys to the *library's*
-  // stable exercise id (the value of primary[libId] post-migration), NOT the session-
-  // exercise doc id. This survives renames since the id is stable.
+  // Pre-fetch existing PRs for all exercises to compare. See deriveExerciseKey
+  // for the key shape; it returns null (skip) rather than persist a wrong-shape
+  // key, which would corrupt post-migration history.
   const exerciseKeys = exercises
-    .map((ex) => {
-      if (ex.exerciseKey) return ex.exerciseKey;
-      const primary = (ex as Record<string, unknown>).primary as Record<string, string> | undefined;
-      const libId = ex.libraryId ?? (primary ? Object.keys(primary)[0] : null);
-      const libraryExId = libId && primary ? primary[libId] : null;
-      if (libId && libraryExId) return `${libId}_${libraryExId}`;
-      // Do NOT fall back to ${libId}_${ex.exerciseName} — that was the pre-migration shape.
-      // Writing it post-migration corrupts history because rekeyed docs use ${libId}_${exerciseId}.
-      // Any caller missing both exerciseKey and primary[libId] indicates a bug; skip the
-      // history write rather than persist a wrong-shape key.
-      return null;
-    })
+    .map((ex) => deriveExerciseKey(ex as Record<string, unknown>))
     .filter(Boolean) as string[];
+
+  // ── Reopen handling ──────────────────────────────────────────────────────
+  // When replacesCompletionId is set, the client is re-finishing a session that
+  // was already completed (un-finished from the Hoy card). We must REPLACE that
+  // session's footprint, not append a duplicate: reuse its id + original date,
+  // and read the old session plus every affected history/lastPerformance doc so
+  // we can swap this session's contribution and recompute the derived aggregates.
+  const replaceId = body.replacesCompletionId;
+  let effectiveCompletionId = completionId;
+  let effectiveCompletionDate = completionDate;
+  let oldCompletedAt: string | null = null;
+  let isReopen = false;
+  let oldKeys: string[] = [];
+  const oldMuscleVolumes: Record<string, number> = {};
+  const exerciseHistoryMap: Record<string, {
+    sessions: Array<{ date?: string; sessionId?: string; sets?: Array<Record<string, unknown>> }>;
+    exerciseName?: string;
+  }> = {};
+  const reopenLastPerfMap: Record<string, Record<string, unknown>> = {};
+
+  if (replaceId) {
+    const oldDoc = await db
+      .collection("users")
+      .doc(auth.userId)
+      .collection("sessionHistory")
+      .doc(replaceId)
+      .get();
+    if (!oldDoc.exists) {
+      throw new WakeApiServerError("NOT_FOUND", 404, "Sesión no encontrada");
+    }
+    const oldData = oldDoc.data()!;
+    isReopen = true;
+    effectiveCompletionId = replaceId;
+    // Keep the session anchored to its original day — the week bucket and streak
+    // day must not move just because it was re-finished later.
+    effectiveCompletionDate = (oldData.date as string) ?? completionDate;
+    oldCompletedAt = (oldData.completedAt as string) ?? null;
+
+    const oldExercises = (oldData.exercises as Array<Record<string, unknown>>) ?? [];
+    oldKeys = oldExercises
+      .map((ex) => deriveExerciseKey(ex))
+      .filter(Boolean) as string[];
+    for (const ex of oldExercises) {
+      const muscles = (ex.primaryMuscles as string[]) ?? [];
+      const setCount = ((ex.sets as unknown[]) ?? []).length;
+      for (const m of muscles) oldMuscleVolumes[m] = (oldMuscleVolumes[m] ?? 0) + setCount;
+    }
+
+    const unionKeys = Array.from(new Set([...exerciseKeys, ...oldKeys]));
+    const [histDocs, lpDocs] = await Promise.all([
+      Promise.all(unionKeys.map((k) =>
+        db.collection("users").doc(auth.userId).collection("exerciseHistory").doc(k).get())),
+      Promise.all(unionKeys.map((k) =>
+        db.collection("users").doc(auth.userId).collection("exerciseLastPerformance").doc(k).get())),
+    ]);
+    histDocs.forEach((d, i) => {
+      exerciseHistoryMap[unionKeys[i]] = d.exists ?
+        (d.data() as typeof exerciseHistoryMap[string]) :
+        {sessions: []};
+    });
+    lpDocs.forEach((d, i) => {
+      if (d.exists) reopenLastPerfMap[unionKeys[i]] = d.data()!;
+    });
+  }
 
   // Fetch library docs to hydrate displayName for sessionHistory.exercises (W-7) and
   // lastPerformance.exerciseName (W-4). Without this, both surfaces persist whatever the
@@ -1598,9 +1728,12 @@ router.post("/workout/complete", async (req, res) => {
   const userDoc = await db.collection("users").doc(auth.userId).get();
   const userData = userDoc.data() ?? {};
 
-  // Update streak via shared function (full read already done, pass lastKnown to avoid re-read)
+  // Update streak via shared function (full read already done, pass lastKnown to avoid re-read).
+  // Reopen re-finishes an existing day, which is already counted — skip so we don't double-count.
   const storedLastActivity = userData.activityStreak?.lastActivityDate ?? userData.lastSessionDate ?? null;
-  const streakResult = await updateStreak(auth.userId, completionDate, storedLastActivity);
+  const streakResult = isReopen ?
+    {updated: false} :
+    await updateStreak(auth.userId, completionDate, storedLastActivity);
 
   // Compute 1RM per exercise and detect PRs
   const personalRecords: Array<{
@@ -1612,20 +1745,22 @@ router.post("/workout/complete", async (req, res) => {
 
   const batch = db.batch();
 
-  // 1. Session history
+  // 1. Session history. On reopen this overwrites the original doc in place
+  // (same id), preserving its original date + completedAt so it stays ordered
+  // where it was; only the performed exercises, duration and notes change.
   const sessionHistoryRef = db
     .collection("users")
     .doc(auth.userId)
     .collection("sessionHistory")
-    .doc(completionId);
+    .doc(effectiveCompletionId);
 
   batch.set(sessionHistoryRef, {
     courseId: body.courseId,
     sessionId: body.sessionId,
     exercises: hydratedExercises,
     durationMs: body.durationMs,
-    date: completionDate,
-    completedAt: body.completedAt,
+    date: effectiveCompletionDate,
+    completedAt: isReopen && oldCompletedAt ? oldCompletedAt : body.completedAt,
     userNotes: body.userNotes ?? null,
     plannedSnapshot: body.plannedSnapshot ?? null,
     ...(body.courseName ? {courseName: body.courseName} : {}),
@@ -1633,39 +1768,38 @@ router.post("/workout/complete", async (req, res) => {
     completed_at: FieldValue.serverTimestamp(),
   });
 
-  // 2. Exercise history + last performance + 1RM per exercise
+  // 2. Exercise history + last performance + 1RM per exercise.
+  // `notes` is the coach's prescriptive instruction for the upcoming set — not a
+  // record of what the user did. Strip it before persisting so history docs don't
+  // bloat with up-to-500-char strings the user never authored.
+  const stripNotes = (s: Record<string, unknown>): Record<string, unknown> => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const {notes: _n, ...rest} = s;
+    return rest;
+  };
+  const newKeySet = new Set<string>();
+
   for (let i = 0; i < hydratedExercises.length; i++) {
     const exercise = hydratedExercises[i];
     const exerciseKey = exerciseKeys[i];
     if (!exerciseKey) continue;
+    newKeySet.add(exerciseKey);
 
-    let bestEstimate1RM = 0;
-    let bestSet: { weight: number; reps: number; intensity: string | null } | null = null;
+    const historySets = (exercise.sets ?? []).map(stripNotes);
+    const {estimate: bestEstimate1RM, bestSet} = computeBest1RM(historySets);
 
-    for (const set of exercise.sets ?? []) {
-      const weight = set.weight ?? 0;
-      const reps = set.reps ?? 0;
-      if (weight <= 0 || reps <= 0) continue;
+    // PR detection. Normal path compares against the stored lastPerformance
+    // estimate; reopen compares against the best of the user's OTHER sessions for
+    // this exercise (excluding the one being replaced) so the check isn't circular.
+    const comparisonEstimate = isReopen ?
+      bestEstimateFromSessions(exerciseHistoryMap[exerciseKey]?.sessions ?? [], effectiveCompletionId) :
+      (existingPrMap[exerciseKey]?.estimate1RM ?? 0);
+    const hadPrior = isReopen ? comparisonEstimate > 0 : !!existingPrMap[exerciseKey];
 
-      const intensity =
-        parseReportedIntensity(set.intensity) ??
-        parsePlannedIntensity(set.plannedIntensity) ??
-        null;
-      const estimate = calculate1RM(weight, reps, intensity);
-
-      if (estimate > bestEstimate1RM) {
-        bestEstimate1RM = estimate;
-        bestSet = {weight, reps, intensity: set.intensity ?? null};
-      }
-    }
-
-    const existingPr = existingPrMap[exerciseKey];
-    const existingEstimate = existingPr?.estimate1RM ?? 0;
-
-    // Only count as PR if there's a previous record to beat (not first-time exercises)
-    if (existingPr && bestEstimate1RM > existingEstimate && bestSet) {
-      // exercise.exerciseName is hydrated above. Don't fall through to exerciseKey
-      // (which is `${libId}_${exerciseId}`) — that surfaces a 20-char id in the PR card.
+    // Only count as PR if there's a previous record to beat (not first-time exercises).
+    // exercise.exerciseName is hydrated above; don't fall through to exerciseKey
+    // (which is `${libId}_${exerciseId}`) — that surfaces a 20-char id in the PR card.
+    if (hadPrior && bestEstimate1RM > comparisonEstimate && bestSet) {
       personalRecords.push({
         exerciseKey,
         exerciseName: exercise.exerciseName ?? "Ejercicio",
@@ -1679,64 +1813,104 @@ router.post("/workout/complete", async (req, res) => {
       .doc(auth.userId)
       .collection("exerciseHistory")
       .doc(exerciseKey);
-
-    // `notes` is the coach's prescriptive instruction for the upcoming set —
-    // not a record of what the user did. Strip it before persisting into
-    // exerciseHistory/lastPerformance so historical records don't bloat with
-    // up-to-500-char strings the user never authored.
-    const stripNotes = (s: Record<string, unknown>): Record<string, unknown> => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const {notes: _n, ...rest} = s;
-      return rest;
-    };
-    const historySets = (exercise.sets ?? []).map(stripNotes);
-
-    batch.set(
-      historyRef,
-      {
-        // Store the display name on the history doc so downstream readers
-        // (analytics, PR cards) don't need to cross-reference lastPerformance.
-        exerciseName: exercise.exerciseName ?? null,
-        sessions: FieldValue.arrayUnion({
-          date: completionDate,
-          sessionId: completionId,
-          sets: historySets,
-        }),
-        updated_at: FieldValue.serverTimestamp(),
-      },
-      {merge: true}
-    );
-
     const lastPerfRef = db
       .collection("users")
       .doc(auth.userId)
       .collection("exerciseLastPerformance")
       .doc(exerciseKey);
+    const newEntry = {date: effectiveCompletionDate, sessionId: effectiveCompletionId, sets: historySets};
 
-    // Production format: exerciseId, exerciseName, libraryId, lastSessionId, lastPerformedAt, totalSets, bestSet
-    const exerciseSets = historySets;
-    const prodBestSet = exerciseSets.length > 0 ?
-      exerciseSets.reduce((best: Record<string, unknown>, s: Record<string, unknown>) => {
-        const bw = parseFloat(String(best.weight ?? 0));
-        const sw = parseFloat(String(s.weight ?? 0));
-        return sw > bw ? s : best;
-      }, exerciseSets[0]) :
-      null;
+    if (isReopen) {
+      // Swap this session's entry in the shared history list (filter the old one
+      // out by id, append the new), then recompute lastPerformance from whatever
+      // is now the most-recent session — which correctly leaves a newer session's
+      // lastPerformance untouched if this isn't the latest.
+      const prior = exerciseHistoryMap[exerciseKey]?.sessions ?? [];
+      const rebuilt = [...prior.filter((s) => s.sessionId !== effectiveCompletionId), newEntry];
+      batch.set(historyRef, {
+        exerciseName: exercise.exerciseName ?? null,
+        sessions: rebuilt,
+        updated_at: FieldValue.serverTimestamp(),
+      }, {merge: true});
 
-    batch.set(lastPerfRef, {
-      exerciseId: exercise.exerciseId ?? null,
-      // exercise.exerciseName was hydrated from library above. Avoid fallback to
-      // exercise.exerciseKey or exerciseKey — those are `${libId}_${exerciseId}` and
-      // would persist a 20-char id where the UI expects a display name.
-      exerciseName: exercise.exerciseName ?? null,
-      libraryId: exercise.libraryId ?? null,
-      lastSessionId: completionId,
-      lastPerformedAt: completionDate,
-      totalSets: exerciseSets.length,
-      bestSet: prodBestSet,
-      estimate1RM: bestEstimate1RM > 0 ? Math.round(bestEstimate1RM * 100) / 100 : existingEstimate,
-      updated_at: FieldValue.serverTimestamp(),
-    });
+      const recent = mostRecentSession(rebuilt);
+      const recentSets = recent?.sets ?? [];
+      const {estimate} = computeBest1RM(recentSets);
+      batch.set(lastPerfRef, {
+        exerciseId: exercise.exerciseId ?? null,
+        exerciseName: exercise.exerciseName ?? null,
+        libraryId: exercise.libraryId ?? null,
+        lastSessionId: recent?.sessionId ?? effectiveCompletionId,
+        lastPerformedAt: recent?.date ?? effectiveCompletionDate,
+        totalSets: recentSets.length,
+        bestSet: bestSetByWeight(recentSets),
+        estimate1RM: estimate > 0 ? Math.round(estimate * 100) / 100 : 0,
+        updated_at: FieldValue.serverTimestamp(),
+      });
+    } else {
+      // Store the display name on the history doc so downstream readers
+      // (analytics, PR cards) don't need to cross-reference lastPerformance.
+      batch.set(historyRef, {
+        exerciseName: exercise.exerciseName ?? null,
+        sessions: FieldValue.arrayUnion(newEntry),
+        updated_at: FieldValue.serverTimestamp(),
+      }, {merge: true});
+
+      const existingEstimate = existingPrMap[exerciseKey]?.estimate1RM ?? 0;
+      batch.set(lastPerfRef, {
+        exerciseId: exercise.exerciseId ?? null,
+        exerciseName: exercise.exerciseName ?? null,
+        libraryId: exercise.libraryId ?? null,
+        lastSessionId: effectiveCompletionId,
+        lastPerformedAt: effectiveCompletionDate,
+        totalSets: historySets.length,
+        bestSet: bestSetByWeight(historySets),
+        estimate1RM: bestEstimate1RM > 0 ? Math.round(bestEstimate1RM * 100) / 100 : existingEstimate,
+        updated_at: FieldValue.serverTimestamp(),
+      });
+    }
+  }
+
+  // 2b. Reopen only: exercises that were in the OLD session but removed in this
+  // re-finish. Pull this session out of their history and re-point (or clear)
+  // lastPerformance so nothing references a contribution that no longer exists.
+  if (isReopen) {
+    const removedKeys = oldKeys.filter((k) => !newKeySet.has(k));
+    for (const exerciseKey of removedKeys) {
+      const prior = exerciseHistoryMap[exerciseKey]?.sessions ?? [];
+      const rebuilt = prior.filter((s) => s.sessionId !== effectiveCompletionId);
+      const historyRef = db
+        .collection("users")
+        .doc(auth.userId)
+        .collection("exerciseHistory")
+        .doc(exerciseKey);
+      const lastPerfRef = db
+        .collection("users")
+        .doc(auth.userId)
+        .collection("exerciseLastPerformance")
+        .doc(exerciseKey);
+      batch.set(historyRef, {sessions: rebuilt, updated_at: FieldValue.serverTimestamp()}, {merge: true});
+
+      const recent = mostRecentSession(rebuilt);
+      if (recent) {
+        const recentSets = recent.sets ?? [];
+        const {estimate} = computeBest1RM(recentSets);
+        const existing = reopenLastPerfMap[exerciseKey] ?? {};
+        batch.set(lastPerfRef, {
+          exerciseId: existing.exerciseId ?? null,
+          exerciseName: existing.exerciseName ?? null,
+          libraryId: existing.libraryId ?? null,
+          lastSessionId: recent.sessionId ?? null,
+          lastPerformedAt: recent.date ?? null,
+          totalSets: recentSets.length,
+          bestSet: bestSetByWeight(recentSets),
+          estimate1RM: estimate > 0 ? Math.round(estimate * 100) / 100 : 0,
+          updated_at: FieldValue.serverTimestamp(),
+        });
+      } else {
+        batch.delete(lastPerfRef);
+      }
+    }
   }
 
   // 3. Compute muscle volumes from exercises
@@ -1749,36 +1923,30 @@ router.post("/workout/complete", async (req, res) => {
     }
   }
 
-  // 3b. Compute week key for weeklyMuscleVolume persistence
-  // Must match client-side getMondayWeek() in apps/pwa/src/utils/weekCalculation.js
-  const completionDateObj = new Date(completionDate);
-  completionDateObj.setHours(0, 0, 0, 0);
-  const dayOfWeek = completionDateObj.getDay();
-  const mondayOffset = completionDateObj.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1);
-  const monday = new Date(completionDateObj);
-  monday.setDate(mondayOffset);
-  const year = monday.getFullYear();
-  const jan1 = new Date(year, 0, 1);
-  const jan1Day = jan1.getDay();
-  const daysToFirstMonday = jan1Day === 0 ? 1 : 8 - jan1Day;
-  const firstMonday = new Date(jan1.getTime());
-  firstMonday.setDate(jan1.getDate() + daysToFirstMonday);
-  const daysDiff = Math.floor((monday.getTime() - firstMonday.getTime()) / (24 * 60 * 60 * 1000));
-  const weekNumber = Math.floor(daysDiff / 7) + 1;
-  const weekKey = `${year}-W${String(weekNumber).padStart(2, "0")}`;
+  // 3b. Week key for weeklyMuscleVolume persistence — anchored to the session's
+  // effective date (its original day on reopen). getMondayWeek matches the
+  // client-side getMondayWeek() in apps/pwa/src/utils/weekCalculation.js.
+  const weekKey = getMondayWeek(new Date(effectiveCompletionDate));
 
-  // Merge session volumes into existing weekly volumes (additive)
+  // Apply the session's volume to the week bucket. On reopen this is a delta —
+  // the old contribution is subtracted and the new one added (same bucket, since
+  // the date is preserved) — so a re-finish never double-counts. Normal path has
+  // no old volume, so delta === the new volume (plain additive, unchanged).
   const weeklyVolumeUpdate: Record<string, unknown> = {};
-  const existingWeeklyVolume = userData.weeklyMuscleVolume?.[weekKey] ?? {};
-  for (const [muscle, sets] of Object.entries(muscleVolumes)) {
-    const existing = (existingWeeklyVolume as Record<string, number>)[muscle] ?? 0;
-    weeklyVolumeUpdate[`weeklyMuscleVolume.${weekKey}.${muscle}`] = existing + sets;
+  const existingWeeklyVolume = (userData.weeklyMuscleVolume?.[weekKey] ?? {}) as Record<string, number>;
+  const volumeMuscles = new Set([...Object.keys(muscleVolumes), ...Object.keys(oldMuscleVolumes)]);
+  for (const muscle of volumeMuscles) {
+    const delta = (muscleVolumes[muscle] ?? 0) - (isReopen ? (oldMuscleVolumes[muscle] ?? 0) : 0);
+    if (delta === 0) continue;
+    const next = (existingWeeklyVolume[muscle] ?? 0) + delta;
+    weeklyVolumeUpdate[`weeklyMuscleVolume.${weekKey}.${muscle}`] = next < 0 ? 0 : next;
   }
 
-  // 4. Update user last session + weekly volume (streak already updated by updateStreak above)
+  // 4. Update user weekly volume (+ lastSessionDate, except on reopen — re-finishing
+  // an older session must not move the user's last-activity day backward).
   const userRef = db.collection("users").doc(auth.userId);
   batch.update(userRef, {
-    lastSessionDate: completionDate,
+    ...(isReopen ? {} : {lastSessionDate: completionDate}),
     ...weeklyVolumeUpdate,
     updated_at: FieldValue.serverTimestamp(),
   });
@@ -1797,7 +1965,7 @@ router.post("/workout/complete", async (req, res) => {
 
   res.json({
     data: {
-      completionId,
+      completionId: effectiveCompletionId,
       personalRecords,
       streakUpdated: streakResult.updated,
       muscleVolumes,


### PR DESCRIPTION
Consolida en main el trabajo pendiente de la rama de suscripción más un fix de producción detectado al revisar logs.

## Incluye
- **fix(firestore): índice collection-group para `subscriptions.status`** — `reconcileSubscriptions` corre `collectionGroup("subscriptions").where("status","in",[...])` a diario y requiere un índice `COLLECTION_GROUP_ASC` sobre `status` que faltaba. Cada corrida programada desde al menos 2026-06-04 fallaba con `FAILED_PRECONDITION` y el estado de suscripciones nunca se reconciliaba. Ya **desplegado** a `wolf-20b8b`.
- Feature de **proactive subscription email** + **transparent subscription checkout** (payments.ts, public.ts, screens de PWA/landing, docs de diseño) — commiteado previamente como snapshots de deploy.

## Contexto
Detectado cruzando logs de producción (Firebase Functions) con PostHog. El cron llevaba ~5 días fallando silenciosamente; relevante para el gating de los monthly drops y los emails de suscripción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)