### PR TITLE
feat(abs): Código ABS niveles — creator UI (shell→plans) + API allowlists

### DIFF
--- a/apps/creator-dashboard/src/components/program/GroupProgramView.css
+++ b/apps/creator-dashboard/src/components/program/GroupProgramView.css
@@ -1367,3 +1367,84 @@
   line-height: 1.45;
   margin: 0;
 }
+
+/* ─── LevelPlansConfig ───────────────────────────────────────── */
+.lpc-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.lpc-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.lpc-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.lpc-row--default {
+  margin-top: 4px;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.lpc-row__label {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.55);
+  flex-shrink: 0;
+}
+
+.lpc-row__select {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  border-radius: 8px;
+  padding: 7px 10px;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.85);
+  outline: none;
+  font-family: inherit;
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
+  transition: border-color 200ms cubic-bezier(0.22, 1, 0.36, 1);
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+.lpc-row__select:focus {
+  border-color: rgba(var(--gp-accent-r), var(--gp-accent-g), var(--gp-accent-b), 0.4);
+}
+
+.lpc-footer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.lpc-save-btn {
+  flex-shrink: 0;
+}
+
+.lpc-save-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.lpc-error {
+  font-size: 12px;
+  color: rgba(255, 100, 100, 0.9);
+  margin: 0;
+}
+
+.lpc-success {
+  font-size: 12px;
+  color: rgba(100, 220, 130, 0.9);
+  margin: 0;
+}

--- a/apps/creator-dashboard/src/components/program/GroupProgramView.jsx
+++ b/apps/creator-dashboard/src/components/program/GroupProgramView.jsx
@@ -12,6 +12,7 @@ import NumberTicker from '../ui/NumberTicker';
 import ProgramRevenueCard from './ProgramRevenueCard';
 import ProgramTrainingTab from './ProgramTrainingTab';
 import ProgramNutritionTab from './ProgramNutritionTab';
+import LevelPlansConfig from './LevelPlansConfig';
 import { ResponsiveContainer, AreaChart, Area, YAxis } from 'recharts';
 import { extractAccentFromImage } from '../events/eventFieldComponents';
 import { detectVideoSource, getEmbedUrl } from '../../utils/videoUtils';
@@ -754,6 +755,16 @@ export default function GroupProgramView({ program, programId, backTo, refetchPr
                     </p>
                   )}
                 </BentoCard>
+
+                {/* Level plans config — maps principiante/intermedio/avanzado
+                    each to an existing plan. Writes levels + level_plans on
+                    the program shell doc. Toggle off = no-op (program behaves
+                    as today). */}
+                <LevelPlansConfig
+                  programId={programId}
+                  creatorId={user?.uid}
+                  initial={{ levels: program?.levels, level_plans: program?.level_plans }}
+                />
 
                 {/* Weight suggestions */}
                 <BentoCard className="gp-config__card">

--- a/apps/creator-dashboard/src/components/program/LevelPlansConfig.jsx
+++ b/apps/creator-dashboard/src/components/program/LevelPlansConfig.jsx
@@ -22,11 +22,19 @@ export default function LevelPlansConfig({ programId, initial, creatorId }) {
   const [mapping, setMapping] = useState(initial?.level_plans ?? {});
   const [disabling, setDisabling] = useState(false);
 
+  // Re-sync from the server ONLY when the persisted value actually changes —
+  // not on every parent render. `initial` is a fresh object literal each render,
+  // so depending on it directly would revert the user's toggle/edits constantly.
+  const serverSig = JSON.stringify({
+    levels: initial?.levels ?? null,
+    level_plans: initial?.level_plans ?? null,
+  });
   useEffect(() => {
     setEnabled(!!initial?.levels);
     setDef(initial?.levels?.default ?? 'principiante');
     setMapping(initial?.level_plans ?? {});
-  }, [initial]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [serverSig]);
 
   const { data: plans = [], isLoading: plansLoading } = useQuery({
     queryKey: ['library', 'plans', creatorId],

--- a/apps/creator-dashboard/src/components/program/LevelPlansConfig.jsx
+++ b/apps/creator-dashboard/src/components/program/LevelPlansConfig.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import programService from '../../services/programService';
 import plansService from '../../services/plansService';
@@ -20,6 +20,13 @@ export default function LevelPlansConfig({ programId, initial, creatorId }) {
   const [enabled, setEnabled] = useState(!!initial?.levels);
   const [def, setDef] = useState(initial?.levels?.default ?? 'principiante');
   const [mapping, setMapping] = useState(initial?.level_plans ?? {});
+  const [disabling, setDisabling] = useState(false);
+
+  useEffect(() => {
+    setEnabled(!!initial?.levels);
+    setDef(initial?.levels?.default ?? 'principiante');
+    setMapping(initial?.level_plans ?? {});
+  }, [initial]);
 
   const { data: plans = [], isLoading: plansLoading } = useQuery({
     queryKey: ['library', 'plans', creatorId],
@@ -40,14 +47,23 @@ export default function LevelPlansConfig({ programId, initial, creatorId }) {
   });
 
   const handleDisable = async () => {
+    setDisabling(true);
     setEnabled(false);
     try {
       await programService.updateProgram(programId, { levels: null, level_plans: null });
       qc.invalidateQueries({ queryKey: queryKeys.programs.detail(programId) });
     } catch {
-      // silently reset — the toggle visual already flipped; user can retry
+      setEnabled(true);
+    } finally {
+      setDisabling(false);
     }
   };
+
+  useEffect(() => {
+    if (!save.isSuccess) return;
+    const t = setTimeout(() => save.reset(), 2500);
+    return () => clearTimeout(t);
+  }, [save.isSuccess]);
 
   const isComplete = isLevelConfigComplete(OPTIONS, mapping);
 
@@ -59,6 +75,7 @@ export default function LevelPlansConfig({ programId, initial, creatorId }) {
         <button
           type="button"
           className={`gp-trial__toggle ${enabled ? 'gp-trial__toggle--active' : ''}`}
+          disabled={disabling}
           onClick={() => (enabled ? handleDisable() : setEnabled(true))}
         >
           <span className="gp-trial__toggle-dot" />
@@ -85,8 +102,9 @@ export default function LevelPlansConfig({ programId, initial, creatorId }) {
               <div className="lpc-rows">
                 {OPTIONS.map((opt) => (
                   <div key={opt} className="lpc-row">
-                    <span className="lpc-row__label">{LEVEL_LABELS[opt]}</span>
+                    <label htmlFor={`lpc-select-${opt}`} className="lpc-row__label">{LEVEL_LABELS[opt]}</label>
                     <select
+                      id={`lpc-select-${opt}`}
                       className="lpc-row__select"
                       value={mapping[opt] ?? ''}
                       onChange={(e) =>
@@ -105,8 +123,9 @@ export default function LevelPlansConfig({ programId, initial, creatorId }) {
               </div>
 
               <div className="lpc-row lpc-row--default">
-                <span className="lpc-row__label">Nivel por defecto</span>
+                <label htmlFor="lpc-default" className="lpc-row__label">Nivel por defecto</label>
                 <select
+                  id="lpc-default"
                   className="lpc-row__select"
                   value={def}
                   onChange={(e) => setDef(e.target.value)}
@@ -135,7 +154,7 @@ export default function LevelPlansConfig({ programId, initial, creatorId }) {
                 )}
                 {save.isError && (
                   <p className="lpc-error" role="alert">
-                    No pudimos guardar los niveles. Revisa tu conexion e intenta de nuevo.
+                    No pudimos guardar los niveles. Revisa tu conexión e intenta de nuevo.
                   </p>
                 )}
                 {save.isSuccess && (

--- a/apps/creator-dashboard/src/components/program/LevelPlansConfig.jsx
+++ b/apps/creator-dashboard/src/components/program/LevelPlansConfig.jsx
@@ -1,0 +1,153 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import programService from '../../services/programService';
+import plansService from '../../services/plansService';
+import { buildLevelConfig, isLevelConfigComplete } from '../../utils/levelPlans';
+import { BentoCard } from '../ui/BentoGrid';
+import GlowingEffect from '../ui/GlowingEffect';
+import { queryKeys } from '../../config/queryClient';
+
+const OPTIONS = ['principiante', 'intermedio', 'avanzado'];
+
+const LEVEL_LABELS = {
+  principiante: 'Principiante',
+  intermedio: 'Intermedio',
+  avanzado: 'Avanzado',
+};
+
+export default function LevelPlansConfig({ programId, initial, creatorId }) {
+  const qc = useQueryClient();
+  const [enabled, setEnabled] = useState(!!initial?.levels);
+  const [def, setDef] = useState(initial?.levels?.default ?? 'principiante');
+  const [mapping, setMapping] = useState(initial?.level_plans ?? {});
+
+  const { data: plans = [], isLoading: plansLoading } = useQuery({
+    queryKey: ['library', 'plans', creatorId],
+    queryFn: () => plansService.getPlansByCreator(creatorId),
+    enabled: !!creatorId && enabled,
+    staleTime: 10 * 60 * 1000,
+  });
+
+  const save = useMutation({
+    mutationFn: () =>
+      programService.updateProgram(
+        programId,
+        buildLevelConfig(OPTIONS, def, mapping)
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.programs.detail(programId) });
+    },
+  });
+
+  const handleDisable = async () => {
+    setEnabled(false);
+    try {
+      await programService.updateProgram(programId, { levels: null, level_plans: null });
+      qc.invalidateQueries({ queryKey: queryKeys.programs.detail(programId) });
+    } catch {
+      // silently reset — the toggle visual already flipped; user can retry
+    }
+  };
+
+  const isComplete = isLevelConfigComplete(OPTIONS, mapping);
+
+  return (
+    <BentoCard className="gp-config__card gp-config__card--span-2 gp-cadence-card">
+      <GlowingEffect spread={24} proximity={60} />
+      <div className="gp-cadence-card__header">
+        <h3>Planificaciones por nivel</h3>
+        <button
+          type="button"
+          className={`gp-trial__toggle ${enabled ? 'gp-trial__toggle--active' : ''}`}
+          onClick={() => (enabled ? handleDisable() : setEnabled(true))}
+        >
+          <span className="gp-trial__toggle-dot" />
+          <span>{enabled ? 'Activas' : 'Inactivas'}</span>
+        </button>
+      </div>
+
+      {!enabled && (
+        <p className="gp-config__hint">
+          Asigna un plan de entrenamiento distinto para cada nivel. Cuando un cliente entra al programa, recibe el plan de su nivel.
+        </p>
+      )}
+
+      {enabled && (
+        <div className="lpc-body">
+          {plansLoading ? (
+            <p className="gp-config__hint">Cargando planes...</p>
+          ) : plans.length === 0 ? (
+            <p className="gp-config__hint">
+              No tienes planes creados. Crea al menos tres desde Biblioteca antes de configurar los niveles.
+            </p>
+          ) : (
+            <>
+              <div className="lpc-rows">
+                {OPTIONS.map((opt) => (
+                  <div key={opt} className="lpc-row">
+                    <span className="lpc-row__label">{LEVEL_LABELS[opt]}</span>
+                    <select
+                      className="lpc-row__select"
+                      value={mapping[opt] ?? ''}
+                      onChange={(e) =>
+                        setMapping((m) => ({ ...m, [opt]: e.target.value }))
+                      }
+                    >
+                      <option value="">Elegir plan</option>
+                      {plans.map((p) => (
+                        <option key={p.id} value={p.id}>
+                          {p.title}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                ))}
+              </div>
+
+              <div className="lpc-row lpc-row--default">
+                <span className="lpc-row__label">Nivel por defecto</span>
+                <select
+                  className="lpc-row__select"
+                  value={def}
+                  onChange={(e) => setDef(e.target.value)}
+                >
+                  {OPTIONS.map((o) => (
+                    <option key={o} value={o}>
+                      {LEVEL_LABELS[o]}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="lpc-footer">
+                <button
+                  type="button"
+                  className="gp-config__btn lpc-save-btn"
+                  disabled={!isComplete || save.isPending}
+                  onClick={() => save.mutate()}
+                >
+                  {save.isPending ? 'Guardando...' : 'Guardar'}
+                </button>
+                {!isComplete && (
+                  <p className="gp-config__hint">
+                    Asigna un plan a cada nivel para poder guardar.
+                  </p>
+                )}
+                {save.isError && (
+                  <p className="lpc-error" role="alert">
+                    No pudimos guardar los niveles. Revisa tu conexion e intenta de nuevo.
+                  </p>
+                )}
+                {save.isSuccess && (
+                  <p className="lpc-success" role="status">
+                    Niveles guardados.
+                  </p>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </BentoCard>
+  );
+}

--- a/apps/creator-dashboard/src/screens/LibrarySessionDetailScreen.css
+++ b/apps/creator-dashboard/src/screens/LibrarySessionDetailScreen.css
@@ -324,6 +324,37 @@
   font-weight: 500;
 }
 
+.lss-select {
+  flex: 1;
+  height: 36px;
+  padding: 0 12px;
+  font-size: 14px;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.90);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  border-radius: 8px;
+  font-family: inherit;
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M6 9L12 15L18 9' stroke='rgba(255,255,255,0.45)' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+  padding-right: 32px;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.lss-select:focus {
+  outline: none;
+  border-color: rgba(255, 255, 255, 0.25);
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.lss-select option {
+  background: #2a2a2a;
+  color: rgba(255, 255, 255, 0.90);
+}
+
 /* ── Expanded 3-card layout ── */
 .lss-expanded {
   display: flex;

--- a/apps/creator-dashboard/src/screens/LibrarySessionDetailScreen.jsx
+++ b/apps/creator-dashboard/src/screens/LibrarySessionDetailScreen.jsx
@@ -1113,6 +1113,10 @@ const LibrarySessionDetailScreen = () => {
   const titleSaveTimerRef = useRef(null);
   const effectiveTitle = localTitle ?? session?.title ?? '';
 
+  // Editable weekIndex (plan instance only)
+  const [localWeekIndex, setLocalWeekIndex] = useState(undefined);
+  const effectiveWeekIndex = localWeekIndex !== undefined ? localWeekIndex : (session?.weekIndex ?? null);
+
   // Sync localTitle when session data loads for the first time
   useEffect(() => {
     if (session?.title && localTitle === null) {
@@ -1346,6 +1350,21 @@ const LibrarySessionDetailScreen = () => {
         });
     }, 500);
   }, [user, sessionId, contentApi, queryClient, showToast]);
+
+  const handleWeekIndexChange = useCallback((value) => {
+    const weekIndex = value === '' ? null : Number(value);
+    setLocalWeekIndex(weekIndex);
+    if (!user || !sessionId || !instanceService || !instanceId || !instanceModuleId) return;
+    instanceService.updateSession(instanceId, instanceModuleId, sessionId, { weekIndex })
+      .then(() => {
+        setHasMadeChanges(true);
+        queryClient.invalidateQueries({ queryKey: ['library', 'session', sessionId] });
+      })
+      .catch((err) => {
+        logger.error('Error saving weekIndex:', err);
+        showToast('No pudimos guardar la semana. Intenta de nuevo.', 'error');
+      });
+  }, [user, sessionId, instanceService, instanceId, instanceModuleId, queryClient, showToast]);
 
   useEffect(() => {
     if (isPresetSelectorOpen && user?.uid) {
@@ -3764,6 +3783,25 @@ const LibrarySessionDetailScreen = () => {
                     onClick={(e) => e.stopPropagation()}
                   />
                 </div>
+                {isPlanInstanceEdit && (
+                  <div className="lss-title-row">
+                    <label className="lss-title-label" htmlFor="lss-week-index-select">Semana del mes</label>
+                    <select
+                      id="lss-week-index-select"
+                      className="lss-select"
+                      value={effectiveWeekIndex === null || effectiveWeekIndex === undefined ? '' : String(effectiveWeekIndex)}
+                      onChange={(e) => handleWeekIndexChange(e.target.value)}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <option value="">Todas las semanas</option>
+                      <option value="0">Semana 1</option>
+                      <option value="1">Semana 2</option>
+                      <option value="2">Semana 3</option>
+                      <option value="3">Semana 4</option>
+                      <option value="4">Semana 5</option>
+                    </select>
+                  </div>
+                )}
                 <div className="lss-expanded">
                 {/* Card 1: Image */}
                 <div className="lsd-glow-wrap lsd-glow-wrap--card lsd-glow-wrap--image">

--- a/apps/creator-dashboard/src/screens/LibrarySessionDetailScreen.jsx
+++ b/apps/creator-dashboard/src/screens/LibrarySessionDetailScreen.jsx
@@ -1358,9 +1358,11 @@ const LibrarySessionDetailScreen = () => {
     instanceService.updateSession(instanceId, instanceModuleId, sessionId, { weekIndex })
       .then(() => {
         setHasMadeChanges(true);
+        // Unlike handleTitleChange, weekIndex does not appear on session-list cards — no need to invalidate library.sessions or library.sessionsSlim.
         queryClient.invalidateQueries({ queryKey: ['library', 'session', sessionId] });
       })
       .catch((err) => {
+        setLocalWeekIndex(undefined); // revert optimistic override -> falls back to session.weekIndex
         logger.error('Error saving weekIndex:', err);
         showToast('No pudimos guardar la semana. Intenta de nuevo.', 'error');
       });

--- a/apps/creator-dashboard/src/utils/levelPlans.js
+++ b/apps/creator-dashboard/src/utils/levelPlans.js
@@ -1,0 +1,12 @@
+export function buildLevelConfig(options, defaultLevel, mapping) {
+  const level_plans = {};
+  for (const opt of options) {
+    const planId = mapping?.[opt];
+    if (planId) level_plans[opt] = planId;
+  }
+  return { levels: { options, default: defaultLevel }, level_plans };
+}
+
+export function isLevelConfigComplete(options, mapping) {
+  return options.length > 0 && options.every((o) => !!mapping?.[o]);
+}

--- a/apps/creator-dashboard/src/utils/levelPlans.test.js
+++ b/apps/creator-dashboard/src/utils/levelPlans.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { buildLevelConfig, isLevelConfigComplete } from './levelPlans';
+
+describe('buildLevelConfig', () => {
+  it('builds { levels, level_plans } from a mapping', () => {
+    const out = buildLevelConfig(
+      ['principiante', 'intermedio', 'avanzado'],
+      'principiante',
+      { principiante: 'p1', intermedio: 'p2', avanzado: 'p3' }
+    );
+    expect(out).toEqual({
+      levels: { options: ['principiante', 'intermedio', 'avanzado'], default: 'principiante' },
+      level_plans: { principiante: 'p1', intermedio: 'p2', avanzado: 'p3' },
+    });
+  });
+  it('omits levels with no plan selected', () => {
+    const out = buildLevelConfig(['principiante', 'avanzado'], 'principiante', { principiante: 'p1', avanzado: '' });
+    expect(out.level_plans).toEqual({ principiante: 'p1' });
+  });
+});
+
+describe('isLevelConfigComplete', () => {
+  it('true when every option maps to a plan', () => {
+    expect(isLevelConfigComplete(['a', 'b'], { a: 'p1', b: 'p2' })).toBe(true);
+  });
+  it('false when an option is unmapped', () => {
+    expect(isLevelConfigComplete(['a', 'b'], { a: 'p1', b: '' })).toBe(false);
+  });
+});

--- a/apps/landing/src/screens/CreatorProgramDetailScreen.jsx
+++ b/apps/landing/src/screens/CreatorProgramDetailScreen.jsx
@@ -8,6 +8,7 @@ import {
   StorefrontCheckoutError,
 } from '../services/storefrontCheckoutService';
 import { getCurrentUser } from '../services/storefrontAuthService';
+import analyticsService from '../services/analyticsService';
 import { useAccentFromImage } from '../utils/accentColor';
 import AuthModal from '../components/AuthModal';
 import './CreatorProgramDetailScreen.css';
@@ -131,6 +132,10 @@ export default function CreatorProgramDetailScreen() {
   const [checkoutError, setCheckoutError] = useState(null);
   const [altEmail, setAltEmail] = useState('');
   const [needsAltEmail, setNeedsAltEmail] = useState(false);
+  // Proactive subscription email confirm step: false = hidden; when true,
+  // one-tap confirm of the account email or switch to a custom MP email.
+  const [emailStep, setEmailStep] = useState(false);
+  const [useCustomEmail, setUseCustomEmail] = useState(false);
   const [alreadyOwned, setAlreadyOwned] = useState(null);
   // Sold-out waitlist: 'hidden' (just the CTA) | 'form' | 'done'.
   const [waitlistPhase, setWaitlistPhase] = useState('hidden');
@@ -284,6 +289,15 @@ export default function CreatorProgramDetailScreen() {
             window.sessionStorage.setItem(`wake_payer_${program.id}`, payer);
           }
         } catch { /* private mode — fall through */ }
+        if (mode === 'subscription') {
+          try {
+            analyticsService.track('subscription.checkout.redirected', {
+              course_id: program.id,
+              surface: 'landing',
+              subscription_id: result.subscriptionId || null,
+            });
+          } catch { /* analytics is best-effort */ }
+        }
         window.location.href = result.initPoint;
         return;
       }
@@ -308,9 +322,21 @@ export default function CreatorProgramDetailScreen() {
     window.location.href = url;
   };
 
+  // Subscriptions: confirm the Mercado Pago email BEFORE creating the
+  // preapproval (it binds to that email and can't be re-bound). One-time
+  // payments go straight to checkout.
+  const startForMode = (mode) => {
+    if (mode === 'subscription') {
+      openEmailStep();
+    } else {
+      runCheckout(mode);
+    }
+  };
+
   const handleBuy = (mode) => {
     setCheckoutError(null);
     setNeedsAltEmail(false);
+    setEmailStep(false);
     setAlreadyOwned(null);
     setAltEmail('');
     setPendingMode(mode);
@@ -325,7 +351,7 @@ export default function CreatorProgramDetailScreen() {
       return;
     }
     if (getCurrentUser()) {
-      runCheckout(mode);
+      startForMode(mode);
     } else {
       setAuthOpen(true);
     }
@@ -338,8 +364,43 @@ export default function CreatorProgramDetailScreen() {
       return;
     }
     if (pendingMode) {
-      runCheckout(pendingMode);
+      startForMode(pendingMode);
     }
+  };
+
+  const openEmailStep = () => {
+    setEmailStep(true);
+    setUseCustomEmail(false);
+    setAltEmail('');
+    setCheckoutError(null);
+    try {
+      analyticsService.track('subscription.email_step.shown', {
+        course_id: program.id,
+        surface: 'landing',
+      });
+    } catch { /* analytics is best-effort */ }
+  };
+
+  const confirmEmailStep = (e) => {
+    if (e) e.preventDefault();
+    const accountEmail = (getCurrentUser()?.email || '').trim().toLowerCase();
+    const chosen = useCustomEmail ? altEmail.trim().toLowerCase() : accountEmail;
+    if (!EMAIL_RE.test(chosen)) {
+      setCheckoutError('Correo inválido.');
+      return;
+    }
+    try {
+      analyticsService.track('subscription.email_step.choice', {
+        course_id: program.id,
+        surface: 'landing',
+        choice: useCustomEmail ? 'custom' : 'account',
+        emails_differ: chosen !== accountEmail,
+      });
+    } catch { /* analytics is best-effort */ }
+    setEmailStep(false);
+    // Pass an override only for a custom email; undefined lets the backend
+    // default to the account email (and tag emailType "account").
+    runCheckout('subscription', useCustomEmail ? chosen : undefined);
   };
 
   const submitAltEmail = (e) => {
@@ -543,7 +604,7 @@ export default function CreatorProgramDetailScreen() {
                 </>
               )}
             </div>
-          ) : needsAltEmail ? null : (
+          ) : (needsAltEmail || emailStep) ? null : (
             // Hide the primary CTAs while the alt-email form is showing. Both
             // buttons remained visible and clickable, so a user could re-fire
             // a subscription attempt with the wrong email and loop the same
@@ -597,6 +658,67 @@ export default function CreatorProgramDetailScreen() {
                 <span className="cpd-cta-label">Abrir en la app</span>
               </a>
             </div>
+          ) : null}
+
+          {emailStep ? (
+            <form className="cpd-alt-email" onSubmit={confirmEmailStep}>
+              <p className="cpd-alt-email-label">
+                Usa este mismo correo al iniciar sesión en Mercado Pago para completar tu suscripción.
+              </p>
+              {useCustomEmail ? (
+                <input
+                  type="email"
+                  className="cpd-alt-email-input"
+                  placeholder="correo@mercadopago.com"
+                  value={altEmail}
+                  onChange={(e) => setAltEmail(e.target.value)}
+                  maxLength={254}
+                  required
+                  autoFocus
+                  disabled={busyMode !== null}
+                />
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 4, padding: '12px 14px', background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 10, marginBottom: 8 }}>
+                  <span style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'rgba(255,255,255,0.4)' }}>Tu correo</span>
+                  <span style={{ fontSize: 15, color: 'rgba(255,255,255,0.95)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {getCurrentUser()?.email || ''}
+                  </span>
+                </div>
+              )}
+              <button
+                type="submit"
+                className="cpd-cta cpd-cta-primary"
+                disabled={busyMode !== null}
+              >
+                <span className="cpd-cta-label">
+                  {busyMode !== null ? 'Procesando…' : (useCustomEmail ? 'Continuar' : 'Continuar con este correo')}
+                </span>
+              </button>
+              {!useCustomEmail ? (
+                <button
+                  type="button"
+                  className="cpd-alt-email-cancel"
+                  onClick={() => { setUseCustomEmail(true); setAltEmail(''); setCheckoutError(null); }}
+                  disabled={busyMode !== null}
+                >
+                  Usar otro correo de Mercado Pago
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="cpd-alt-email-cancel"
+                onClick={() => {
+                  setEmailStep(false);
+                  setUseCustomEmail(false);
+                  setAltEmail('');
+                  setCheckoutError(null);
+                  setPendingMode(null);
+                }}
+                disabled={busyMode !== null}
+              >
+                Cancelar
+              </button>
+            </form>
           ) : null}
 
           {needsAltEmail ? (

--- a/apps/landing/src/screens/PostPaymentScreen.jsx
+++ b/apps/landing/src/screens/PostPaymentScreen.jsx
@@ -6,6 +6,7 @@ import { getCreatorProgram } from '../services/creatorStorefrontService';
 import { getCheckoutStatus } from '../services/storefrontCheckoutService';
 import { requestMagicLink } from '../services/magicLinkService';
 import { getCurrentIdToken } from '../services/storefrontAuthService';
+import analyticsService from '../services/analyticsService';
 import { getDownloadUrl, getDownloadLabel } from '../utils/smartDownload';
 import './PostPaymentScreen.css';
 
@@ -74,6 +75,7 @@ export default function PostPaymentScreen() {
   // access async; we don't wait).
   const [magicLinkState, setMagicLinkState] = useState('idle'); // idle | sending | sent | failed
   const magicLinkFiredRef = useRef(false);
+  const returnedFiredRef = useRef(false);
   // Firebase restores persisted auth asynchronously; until the first
   // onAuthStateChanged fires we don't know whether the user is signed in
   // or signed out. We must NOT trust the first `null` callback as
@@ -87,6 +89,22 @@ export default function PostPaymentScreen() {
   const [fallbackEmail, setFallbackEmail] = useState('');
   const [fallbackState, setFallbackState] = useState('idle'); // idle | sending | sent | error
   const [fallbackError, setFallbackError] = useState('');
+
+  // Fire once when the buyer lands back from MercadoPago on a subscription
+  // checkout — the "returned" end of the funnel (pairs with
+  // subscription.email_step.shown / choice / .checkout.redirected). Both PWA
+  // and storefront subscriptions redirect here.
+  useEffect(() => {
+    if (!isSubscription || returnedFiredRef.current) return;
+    returnedFiredRef.current = true;
+    try {
+      analyticsService.track('subscription.checkout.returned', {
+        course_id: courseId,
+        surface: 'post_payment',
+        status: status || null,
+      });
+    } catch { /* analytics is best-effort */ }
+  }, [isSubscription, courseId, status]);
 
   // Subscribe to auth state — `auth.currentUser` is null until Firebase
   // restores the session asynchronously after a hard reload. Use a grace

--- a/apps/pwa/src/components/TodayWorkoutCard.web.jsx
+++ b/apps/pwa/src/components/TodayWorkoutCard.web.jsx
@@ -357,6 +357,11 @@ const styles = {
     color: 'rgba(255,255,255,0.4)',
     cursor: 'not-allowed',
   },
+  beginSecondary: {
+    backgroundColor: 'transparent',
+    color: 'rgba(255,255,255,0.85)',
+    border: '1px solid rgba(255,255,255,0.18)',
+  },
   loaderOverlay: {
     position: 'absolute',
     inset: 0,
@@ -531,21 +536,24 @@ const TodayWorkoutCard = ({ course, isExpired = false, downloadStatus = null, se
     setFlipped((f) => !f);
   };
 
-  const handleBegin = (e) => {
+  const handleBegin = (e, mode = 'new') => {
     e?.stopPropagation?.();
     if (isExpired) {
       onRenew?.(course);
       return;
     }
-    if (!canBegin || !onBegin) return;
+    // Completed sessions offer both modes; otherwise require the normal begin gate.
+    if (!sessionState?.workout || !onBegin) return;
+    if (!isCompleted && !canBegin) return;
     onBegin({
       course,
       workout: sessionState?.workout,
       sessionId: sessionState?.session?.sessionId,
+      mode,
     });
   };
 
-  const beginAccentStyle = accent && (canBegin || isExpired)
+  const beginAccentStyle = accent && (canBegin || isExpired || isCompleted)
     ? { backgroundColor: accent.accent, color: accent.accentText }
     : null;
   const beginStyle = canBegin
@@ -699,15 +707,34 @@ const TodayWorkoutCard = ({ course, isExpired = false, downloadStatus = null, se
             </div>
 
             <div style={styles.beginRow}>
-              <button
-                style={canBegin || isExpired
-                  ? { ...styles.beginButton, ...(beginAccentStyle || {}) }
-                  : beginStyle}
-                onClick={handleBegin}
-                disabled={(!canBegin && !isExpired) || sessionLoading}
-              >
-                {beginLabel}
-              </button>
+              {isCompleted && !isExpired ? (
+                <>
+                  <button
+                    style={{ ...styles.beginButton, ...(beginAccentStyle || {}) }}
+                    onClick={(e) => handleBegin(e, 'reopen')}
+                    disabled={sessionLoading || !sessionState?.workout}
+                  >
+                    Continuar sesión
+                  </button>
+                  <button
+                    style={{ ...styles.beginButton, ...styles.beginSecondary }}
+                    onClick={(e) => handleBegin(e, 'new')}
+                    disabled={sessionLoading || !sessionState?.workout}
+                  >
+                    Empezar de nuevo
+                  </button>
+                </>
+              ) : (
+                <button
+                  style={canBegin || isExpired
+                    ? { ...styles.beginButton, ...(beginAccentStyle || {}) }
+                    : beginStyle}
+                  onClick={(e) => handleBegin(e, 'new')}
+                  disabled={(!canBegin && !isExpired) || sessionLoading}
+                >
+                  {beginLabel}
+                </button>
+              )}
             </div>
 
           </div>

--- a/apps/pwa/src/screens/BundleDetailScreen.web.jsx
+++ b/apps/pwa/src/screens/BundleDetailScreen.web.jsx
@@ -4,6 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import apiClient from '../utils/apiClient';
 import { useAuth } from '../contexts/AuthContext';
 import purchaseService from '../services/purchaseService';
+import analyticsService from '../services/analyticsService';
+import logger from '../utils/logger';
 import LoadingScreen from './LoadingScreen';
 import BundleCoverWeb from '../components/bundles/BundleCover.web';
 
@@ -29,6 +31,8 @@ const BundleDetailScreen = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
   const [checkoutState, setCheckoutState] = useState({ kind: null, key: null, loading: false, error: null });
+  // Proactive subscription email step: { email, useCustom, error, submitting } or null.
+  const [emailStep, setEmailStep] = useState(null);
 
   const { data: bundle, isLoading, error } = useQuery({
     queryKey: ['bundle', bundleId],
@@ -60,15 +64,20 @@ const BundleDetailScreen = () => {
       navigate('/login');
       return;
     }
+    // Subscriptions: confirm the Mercado Pago email BEFORE creating the
+    // preapproval (it binds to that email and can't be re-bound). One-time
+    // payments skip this.
+    if (kind === 'sub') {
+      setEmailStep({ email: user?.email || '', useCustom: false, error: null, submitting: false });
+      try {
+        analyticsService.track('subscription.email_step.shown', { bundle_id: bundleId, surface: 'pwa_web' });
+      } catch {}
+      logger.info('[subscription] email step shown (bundle)', { bundleId });
+      return;
+    }
     setCheckoutState({ kind, loading: true, error: null });
     try {
-      let result;
-      if (kind === 'otp') {
-        result = await purchaseService.prepareBundlePurchase(bundleId);
-      } else {
-        const payerEmail = user?.email || null;
-        result = await purchaseService.prepareBundleSubscription(bundleId, payerEmail);
-      }
+      const result = await purchaseService.prepareBundlePurchase(bundleId);
       if (result.success && result.checkoutURL) {
         window.location.href = result.checkoutURL;
       } else {
@@ -79,6 +88,52 @@ const BundleDetailScreen = () => {
       }
     } catch (err) {
       setCheckoutState({ kind, loading: false, error: err.message || 'Error' });
+    }
+  };
+
+  const confirmSubEmail = async () => {
+    if (!emailStep) return;
+    const chosen = (emailStep.email || '').trim();
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(chosen)) {
+      setEmailStep((s) => ({ ...s, error: 'Correo inválido.' }));
+      return;
+    }
+    const accountEmail = (user?.email || '').trim();
+    const emailsDiffer = chosen.toLowerCase() !== accountEmail.toLowerCase();
+    try {
+      analyticsService.track('subscription.email_step.choice', {
+        bundle_id: bundleId,
+        surface: 'pwa_web',
+        choice: emailStep.useCustom ? 'custom' : 'account',
+        emails_differ: emailsDiffer,
+      });
+    } catch {}
+    logger.info('[subscription] email step choice (bundle)', {
+      bundleId, choice: emailStep.useCustom ? 'custom' : 'account', emailsDiffer,
+    });
+    setEmailStep((s) => ({ ...s, submitting: true, error: null }));
+    try {
+      const result = await purchaseService.prepareBundleSubscription(bundleId, chosen, 'pwa_web');
+      if (result.success && result.checkoutURL) {
+        try {
+          analyticsService.track('subscription.checkout.redirected', {
+            bundle_id: bundleId, surface: 'pwa_web', subscription_id: result.subscriptionId || null,
+          });
+        } catch {}
+        logger.info('[subscription] checkout redirected (bundle)', {
+          bundleId, subscriptionId: result.subscriptionId || null,
+        });
+        window.location.href = result.checkoutURL;
+        return;
+      }
+      if (result.requiresAlternateEmail) {
+        setEmailStep((s) => ({ ...s, useCustom: true, submitting: false, error: result.error || 'Ingresa tu correo de Mercado Pago.' }));
+      } else {
+        setEmailStep((s) => ({ ...s, submitting: false, error: result.error || 'No pudimos iniciar el pago.' }));
+      }
+    } catch (err) {
+      setEmailStep((s) => ({ ...s, submitting: false, error: err.message || 'Error' }));
     }
   };
 
@@ -155,6 +210,49 @@ const BundleDetailScreen = () => {
           <div style={styles.loadingBanner}>Preparando el pago…</div>
         )}
       </div>
+
+      {emailStep && (
+        <div style={styles.modalOverlay} onClick={() => setEmailStep(null)}>
+          <div style={styles.modalCard} onClick={(e) => e.stopPropagation()}>
+            <h3 style={styles.modalTitle}>Confirma tu correo de Mercado Pago</h3>
+            <p style={styles.modalDesc}>
+              Usa este mismo correo al iniciar sesión en Mercado Pago para completar tu suscripción.
+            </p>
+            {emailStep.useCustom ? (
+              <input
+                style={styles.modalInput}
+                type="email"
+                placeholder="correo@mercadopago.com"
+                value={emailStep.email}
+                onChange={(e) => setEmailStep((s) => ({ ...s, email: e.target.value, error: null }))}
+                autoFocus
+              />
+            ) : (
+              <div style={styles.emailCard}>
+                <span style={styles.emailCardLabel}>Tu correo</span>
+                <span style={styles.emailCardValue}>{emailStep.email}</span>
+              </div>
+            )}
+            {emailStep.error && <p style={styles.modalError}>{emailStep.error}</p>}
+            <div style={styles.modalButtons}>
+              <button style={styles.modalCancel} onClick={() => setEmailStep(null)} disabled={emailStep.submitting}>
+                Cancelar
+              </button>
+              <button style={styles.modalConfirm} onClick={confirmSubEmail} disabled={emailStep.submitting}>
+                {emailStep.submitting ? 'Procesando…' : (emailStep.useCustom ? 'Continuar' : 'Continuar con este correo')}
+              </button>
+            </div>
+            {!emailStep.useCustom && (
+              <button
+                style={styles.modalSecondary}
+                onClick={() => setEmailStep((s) => ({ ...s, useCustom: true, email: '', error: null }))}
+              >
+                Usar otro correo de Mercado Pago
+              </button>
+            )}
+          </div>
+        </div>
+      )}
     </div>
   );
 };
@@ -328,6 +426,110 @@ const styles = {
     color: 'rgba(255,255,255,0.75)',
     fontSize: 13,
     textAlign: 'center',
+  },
+  modalOverlay: {
+    position: 'fixed',
+    inset: 0,
+    background: 'rgba(0,0,0,0.7)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 9999,
+    padding: 20,
+  },
+  modalCard: {
+    background: '#222',
+    border: '1px solid rgba(255,255,255,0.12)',
+    borderRadius: 16,
+    padding: 24,
+    width: '100%',
+    maxWidth: 380,
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: 700,
+    margin: '0 0 8px',
+  },
+  modalDesc: {
+    fontSize: 13,
+    color: 'rgba(255,255,255,0.6)',
+    margin: '0 0 16px',
+    lineHeight: 1.5,
+  },
+  modalInput: {
+    width: '100%',
+    boxSizing: 'border-box',
+    padding: '12px 14px',
+    background: 'rgba(255,255,255,0.06)',
+    border: '1px solid rgba(255,255,255,0.18)',
+    borderRadius: 10,
+    color: '#fff',
+    fontSize: 15,
+  },
+  emailCard: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+    padding: '12px 14px',
+    background: 'rgba(255,255,255,0.06)',
+    border: '1px solid rgba(255,255,255,0.12)',
+    borderRadius: 10,
+  },
+  emailCardLabel: {
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    color: 'rgba(255,255,255,0.4)',
+  },
+  emailCardValue: {
+    fontSize: 15,
+    color: 'rgba(255,255,255,0.95)',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  modalError: {
+    color: 'rgba(255,180,180,0.95)',
+    fontSize: 13,
+    margin: '12px 0 0',
+  },
+  modalButtons: {
+    display: 'flex',
+    gap: 10,
+    marginTop: 20,
+  },
+  modalCancel: {
+    flex: 1,
+    padding: '12px',
+    background: 'rgba(255,255,255,0.06)',
+    border: '1px solid rgba(255,255,255,0.15)',
+    borderRadius: 100,
+    color: 'rgba(255,255,255,0.7)',
+    fontSize: 14,
+    fontWeight: 600,
+    cursor: 'pointer',
+  },
+  modalConfirm: {
+    flex: 2,
+    padding: '12px',
+    background: 'rgba(255,255,255,0.92)',
+    border: 'none',
+    borderRadius: 100,
+    color: '#111',
+    fontSize: 14,
+    fontWeight: 700,
+    cursor: 'pointer',
+  },
+  modalSecondary: {
+    display: 'block',
+    width: '100%',
+    marginTop: 14,
+    background: 'none',
+    border: 'none',
+    color: 'rgba(255,255,255,0.55)',
+    fontSize: 13,
+    fontWeight: 600,
+    cursor: 'pointer',
   },
 };
 

--- a/apps/pwa/src/screens/CourseDetailScreen.js
+++ b/apps/pwa/src/screens/CourseDetailScreen.js
@@ -39,6 +39,7 @@ import EpaycoWebView from '../components/EpaycoWebView';
 import BookCallSlotModal from '../components/BookCallSlotModal';
 import { getBookingForUser } from '../services/callBookingService';
 import logger from '../utils/logger.js';
+import analyticsService from '../services/analyticsService';
 import { STALE_TIMES } from '../config/queryConfig';
 import { auth } from '../config/firebase';
 import profilePictureService from '../services/profilePictureService';
@@ -105,6 +106,9 @@ const CourseDetailScreen = ({ navigation, route }) => {
   const [showEmailModal, setShowEmailModal] = useState(false);
   const [mercadoPagoEmail, setMercadoPagoEmail] = useState('');
   const [emailModalError, setEmailModalError] = useState('');
+  // Proactive subscription email step: false = one-tap confirm of the account
+  // email; true = user chose to type a different Mercado Pago email.
+  const [useCustomEmail, setUseCustomEmail] = useState(false);
   const [preCheckout, setPreCheckout] = useState(null); // { checkoutURL, mode: 'web'|'native' }
   const [showBookCallModal, setShowBookCallModal] = useState(false);
   const [userCallBooking, setUserCallBooking] = useState(null);
@@ -826,6 +830,26 @@ useEffect(() => {
       return; // Exit early - free flow handled
     }
 
+    // Subscriptions: choose/confirm the Mercado Pago email BEFORE creating the
+    // preapproval, so it binds to the email the user will actually authorize
+    // with (the preapproval can't be re-bound afterwards). One-time payments
+    // skip this — MP's preference checkout accepts any email.
+    const isSubscriptionPurchase = course.access_duration === 'monthly';
+    if (isSubscriptionPurchase) {
+      setMercadoPagoEmail(effectiveUser.email || '');
+      setUseCustomEmail(false);
+      setEmailModalError('');
+      setShowEmailModal(true);
+      try {
+        analyticsService.track('subscription.email_step.shown', {
+          course_id: course.id,
+          surface: isWeb ? 'pwa_web' : 'pwa_native',
+        });
+      } catch {}
+      logger.info('[subscription] email step shown', { courseId: course.id });
+      return;
+    }
+
     // Regular purchase flow - open payment modal
     try {
       setPurchasing(true);
@@ -941,8 +965,26 @@ useEffect(() => {
 
     setEmailModalError('');
     setShowEmailModal(false);
-    
-    // Retry purchase with the provided email
+
+    const chosenEmail = mercadoPagoEmail.trim();
+    const accountEmail = (effectiveUser.email || '').trim();
+    const emailsDiffer = chosenEmail.toLowerCase() !== accountEmail.toLowerCase();
+    const surface = isWeb ? 'pwa_web' : 'pwa_native';
+    try {
+      analyticsService.track('subscription.email_step.choice', {
+        course_id: course.id,
+        surface,
+        choice: useCustomEmail ? 'custom' : 'account',
+        emails_differ: emailsDiffer,
+      });
+    } catch {}
+    logger.info('[subscription] email step choice', {
+      courseId: course.id,
+      choice: useCustomEmail ? 'custom' : 'account',
+      emailsDiffer,
+    });
+
+    // Proceed to subscription checkout with the chosen email.
     try {
       setPurchasing(true);
       setProcessingPurchase(true);
@@ -952,16 +994,19 @@ useEffect(() => {
       readyNotificationSentRef.current = false;
       successAlertShownRef.current = false;
 
-      // Call prepareSubscription directly with the provided email
+      // Call prepareSubscription directly with the chosen email.
       const subscriptionResult = await purchaseService.prepareSubscription(
         effectiveUser.uid,
         course.id,
-        mercadoPagoEmail.trim()
+        chosenEmail,
+        surface
       );
 
       if (!subscriptionResult.success) {
         if (subscriptionResult.requiresAlternateEmail) {
-          // Still requires alternate email - show modal again
+          // MP rejected the email at creation — re-prompt, forcing the custom
+          // input so the user can correct it.
+          setUseCustomEmail(true);
           setShowEmailModal(true);
           setEmailModalError(subscriptionResult.error || 'Este correo no es válido para Mercado Pago. Por favor intenta con otro.');
         } else {
@@ -973,6 +1018,18 @@ useEffect(() => {
         pendingPostPurchaseRef.current = false;
         return;
       }
+
+      try {
+        analyticsService.track('subscription.checkout.redirected', {
+          course_id: course.id,
+          surface,
+          subscription_id: subscriptionResult.subscriptionId || null,
+        });
+      } catch {}
+      logger.info('[subscription] checkout redirected', {
+        courseId: course.id,
+        subscriptionId: subscriptionResult.subscriptionId || null,
+      });
 
       // On web: open MP in a new tab so installed PWAs (iOS standalone) work.
       if (isWeb) {
@@ -1611,42 +1668,51 @@ useEffect(() => {
           }}
         >
           <Pressable style={styles.emailModalContent} onPress={(e) => e.stopPropagation()}>
-            <Text style={styles.emailModalTitle}>Correo de Mercado Pago</Text>
+            <Text style={styles.emailModalTitle}>Confirma tu correo de Mercado Pago</Text>
             <Text style={styles.emailModalDescription}>
-              Mercado Pago necesita un correo distinto para la suscripción. Tu compra se vinculará automáticamente a tu cuenta Wake.
+              Usa este mismo correo al iniciar sesión en Mercado Pago para completar tu suscripción.
             </Text>
-            
-            <TextInput
-              style={[styles.emailModalInput, emailModalError && styles.emailModalInputError]}
-              placeholder="correo@mercadopago.com"
-              placeholderTextColor="rgba(255, 255, 255, 0.5)"
-              value={mercadoPagoEmail}
-              onChangeText={(text) => {
-                setMercadoPagoEmail(text);
-                setEmailModalError('');
-              }}
-              keyboardType="email-address"
-              autoCapitalize="none"
-              autoCorrect={false}
-              autoFocus={true}
-            />
-            
+
+            {useCustomEmail ? (
+              <TextInput
+                style={[styles.emailModalInput, emailModalError && styles.emailModalInputError]}
+                placeholder="correo@mercadopago.com"
+                placeholderTextColor="rgba(255, 255, 255, 0.5)"
+                value={mercadoPagoEmail}
+                onChangeText={(text) => {
+                  setMercadoPagoEmail(text);
+                  setEmailModalError('');
+                }}
+                keyboardType="email-address"
+                autoCapitalize="none"
+                autoCorrect={false}
+                autoFocus={true}
+              />
+            ) : (
+              <View style={styles.preCheckoutEmailCard}>
+                <Text style={styles.preCheckoutEmailLabel}>Tu correo</Text>
+                <Text style={styles.preCheckoutEmailValue} numberOfLines={1}>
+                  {mercadoPagoEmail}
+                </Text>
+              </View>
+            )}
+
             {emailModalError ? (
               <Text style={styles.emailModalErrorText}>{emailModalError}</Text>
             ) : null}
-            
+
             <View style={styles.emailModalButtons}>
               <TouchableOpacity
                 style={[styles.emailModalButton, styles.emailModalButtonCancel]}
                 onPress={() => {
                   setShowEmailModal(false);
                   setEmailModalError('');
-                  setMercadoPagoEmail('');
+                  setUseCustomEmail(false);
                 }}
               >
                 <Text style={styles.emailModalButtonCancelText}>Cancelar</Text>
               </TouchableOpacity>
-              
+
               <TouchableOpacity
                 style={[styles.emailModalButton, styles.emailModalButtonSubmit]}
                 onPress={handleEmailSubmit}
@@ -1655,10 +1721,25 @@ useEffect(() => {
                 {purchasing ? (
                   <ActivityIndicator size="small" color="rgba(255, 255, 255, 1)" />
                 ) : (
-                  <Text style={styles.emailModalButtonSubmitText}>Continuar</Text>
+                  <Text style={styles.emailModalButtonSubmitText}>
+                    {useCustomEmail ? 'Continuar' : 'Continuar con este correo'}
+                  </Text>
                 )}
               </TouchableOpacity>
             </View>
+
+            {!useCustomEmail ? (
+              <TouchableOpacity
+                style={styles.emailModalSecondaryLink}
+                onPress={() => {
+                  setUseCustomEmail(true);
+                  setMercadoPagoEmail('');
+                  setEmailModalError('');
+                }}
+              >
+                <Text style={styles.emailModalSecondaryLinkText}>Usar otro correo de Mercado Pago</Text>
+              </TouchableOpacity>
+            ) : null}
           </Pressable>
         </Pressable>
       </Modal>
@@ -2755,6 +2836,15 @@ const createStyles = (screenWidth, screenHeight) => StyleSheet.create({
     color: 'rgba(255, 255, 255, 1)',
     fontSize: Math.min(screenWidth * 0.045, 18),
     fontWeight: '700',
+  },
+  emailModalSecondaryLink: {
+    marginTop: 16,
+    alignItems: 'center',
+  },
+  emailModalSecondaryLinkText: {
+    color: 'rgba(255, 255, 255, 0.55)',
+    fontSize: Math.min(screenWidth * 0.038, 15),
+    fontWeight: '600',
   },
   videoTabBar: {
     flexDirection: 'row',

--- a/apps/pwa/src/screens/HoyScreen.web.jsx
+++ b/apps/pwa/src/screens/HoyScreen.web.jsx
@@ -353,9 +353,42 @@ const HoyScreen = () => {
     });
   }, [navigate]);
 
-  const handleBeginWorkout = useCallback(({ course, workout, sessionId }) => {
-    navigate('/warmup', { state: { course, workout, sessionId } });
-  }, [navigate]);
+  const handleBeginWorkout = useCallback(async ({ course, workout, sessionId, mode }) => {
+    // "Empezar de nuevo" (and the normal first start) → warmup then a fresh session.
+    if (mode !== 'reopen') {
+      navigate('/warmup', { state: { course, workout, sessionId } });
+      return;
+    }
+
+    // "Continuar sesión" → reopen the already-completed session. Find its saved
+    // record, reshape it into a checkpoint, and drop straight into execution
+    // (skipping warmup, like the recovery flow). On finish, the execution screen
+    // sends reopenCompletionId so the server replaces it instead of duplicating.
+    const cId = course?.courseId || course?.id;
+    if (!cId || !user?.uid) return;
+    const today = new Date().toISOString().slice(0, 10);
+    let completion = null;
+    try {
+      completion = await sessionService.getLatestCompletionForSession(user.uid, cId, sessionId, today);
+    } catch {
+      completion = null;
+    }
+    if (!completion) {
+      // Couldn't locate the completed session — fall back to a fresh start.
+      navigate('/warmup', { state: { course, workout, sessionId } });
+      return;
+    }
+    const checkpoint = sessionService.buildReopenCheckpoint(completion, workout);
+    navigate(`/course/${cId}/workout/execution`, {
+      state: {
+        course,
+        workout,
+        sessionId,
+        checkpoint,
+        reopenCompletionId: completion.completionId || completion.id,
+      },
+    });
+  }, [navigate, user?.uid]);
 
   const handleRenewCourse = useCallback((course) => {
     const id = course?.courseId || course?.id;

--- a/apps/pwa/src/screens/WorkoutExecutionScreen.js
+++ b/apps/pwa/src/screens/WorkoutExecutionScreen.js
@@ -314,15 +314,43 @@ const createStableInputHandler = (exerciseIndex, setIndex, field, updateSetData)
   };
 };
 
+// Merge in-flight input values (typed but not yet flushed to setData via blur)
+// over a setData snapshot. Used at every persistence point so a value that never
+// fired onBlur — row unmounted, app backgrounded, iOS PWA swallowed the blur — is
+// still saved instead of silently dropped.
+const mergeSetData = (base, pending) => {
+  const keys = pending ? Object.keys(pending) : [];
+  if (keys.length === 0) return base;
+  const next = { ...base };
+  keys.forEach(key => {
+    if (pending[key]) next[key] = { ...next[key], ...pending[key] };
+  });
+  return next;
+};
+
 const listInputWrapperStyle = { flex: 1, minWidth: 0 };
 // List view set input: keeps value in local state while focused and flushes to parent on blur.
 // Prevents parent setData updates on every keystroke, which was causing full re-renders and input blur.
 // Freeze on touch/pointer down (before focus) so viewport resize from keyboard doesn't trigger
 // dimension-driven re-renders that dismiss the keyboard on iOS PWA.
-const ListViewSetInputField = memo(({ exerciseIndex, setIndex, field, savedValue, updateSetData, style, placeholderText, listViewInputJustFocusedRef, restoreListViewModelScroll, freezeDimsForListInput, unfreezeDimsForListInput }) => {
+const ListViewSetInputField = memo(({ exerciseIndex, setIndex, field, savedValue, updateSetData, style, placeholderText, listViewInputJustFocusedRef, restoreListViewModelScroll, freezeDimsForListInput, unfreezeDimsForListInput, pendingInputRef }) => {
   const [localValue, setLocalValue] = useState(null);
   const isEditing = localValue !== null;
   const displayValue = isEditing ? localValue : savedValue;
+  // Mirror each keystroke into a screen-level ref synchronously (no re-render, so
+  // it can't dismiss the keyboard). Persistence points read this, so the value is
+  // safe even if onBlur never fires. Cleared once committed to setData on blur.
+  const writePending = useCallback((value) => {
+    if (!pendingInputRef) return;
+    const key = `${exerciseIndex}_${setIndex}`;
+    if (!pendingInputRef.current) pendingInputRef.current = {};
+    pendingInputRef.current[key] = { ...pendingInputRef.current[key], [field]: value };
+  }, [pendingInputRef, exerciseIndex, setIndex, field]);
+  const clearPending = useCallback(() => {
+    if (!pendingInputRef?.current) return;
+    const key = `${exerciseIndex}_${setIndex}`;
+    if (pendingInputRef.current[key]) delete pendingInputRef.current[key][field];
+  }, [pendingInputRef, exerciseIndex, setIndex, field]);
   const onPointerDown = useCallback(() => {
     if (freezeDimsForListInput) freezeDimsForListInput();
   }, [freezeDimsForListInput]);
@@ -339,14 +367,17 @@ const ListViewSetInputField = memo(({ exerciseIndex, setIndex, field, savedValue
     if (unfreezeDimsForListInput) unfreezeDimsForListInput();
     const final = localValue !== null ? localValue : savedValue;
     if (final !== savedValue) updateSetData(exerciseIndex, setIndex, field, final);
+    // Committed to setData (or unchanged) — drop the in-flight copy so it can't
+    // later shadow an edit made through another path (e.g. the set-detail modal).
+    clearPending();
     setLocalValue(null);
-  }, [unfreezeDimsForListInput, localValue, savedValue, exerciseIndex, setIndex, field, updateSetData]);
+  }, [unfreezeDimsForListInput, localValue, savedValue, exerciseIndex, setIndex, field, updateSetData, clearPending]);
   return (
     <View style={listInputWrapperStyle} onPointerDown={onPointerDown} onTouchStart={onPointerDown}>
       <TextInput
         style={style}
         value={displayValue}
-        onChangeText={(value) => setLocalValue(value)}
+        onChangeText={(value) => { setLocalValue(value); writePending(value); }}
         onFocus={onFocus}
         onBlur={onBlur}
         keyboardType="numeric"
@@ -771,6 +802,10 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
   // Set when the user voluntarily discards or successfully completes. Gates the
   // unmount checkpoint flush so it can't resurrect a just-cleared checkpoint.
   const sessionEndedRef = useRef(false);
+  // Holds set-input values typed but not yet flushed to setData on blur, keyed by
+  // `${exerciseIndex}_${setIndex}` → { field: value }. Merged into setData at every
+  // persistence point so an un-flushed weight is never lost.
+  const pendingInputRef = useRef({});
 
   // Ref for focus effect timeout tracking (must be at top level, not inside conditional)
   const focusTimeoutIdsRef = useRef([]);
@@ -1355,6 +1390,7 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
     const currentUser = user || auth.currentUser;
     if (!currentUser || !course || !workout) return null;
     const startTime = workoutStartTimeRef.current || Date.now();
+    const effectiveSetData = mergeSetData(setData, pendingInputRef.current);
     return {
       version: 1,
       userId: currentUser.uid,
@@ -1375,7 +1411,7 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
         })),
       })),
       completedSets: Object.fromEntries(
-        Object.entries(setData).filter(([, v]) =>
+        Object.entries(effectiveSetData).filter(([, v]) =>
           v && typeof v === 'object' && Object.values(v).some(val => val !== '' && val !== null && val !== undefined)
         )
       ),
@@ -2475,6 +2511,14 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
     
     return { evenGap, totalBoxWidth };
   }, [getFieldDisplayName]);
+
+  // Leave the session without discarding: persist a checkpoint (which now folds
+  // in any value typed but not yet flushed on blur) so the user can resume from
+  // Hoy / DailyWorkout. Gives a frustrated user a safe exit that isn't "discard".
+  const handleExitKeepProgress = useCallback(() => {
+    try { saveCheckpointToLocalStorage(); } catch {}
+    navigation.goBack();
+  }, [saveCheckpointToLocalStorage, navigation]);
 
   const handleDiscardWorkout = useCallback(async () => {
     // Use custom modal on web, Alert.alert on native
@@ -4261,10 +4305,13 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
   const executeEndWorkout = useCallback(async () => {
                  try {
                    setIsSavingWorkout(true);
-                   
+
                    // Get user from useAuth hook, fallback to Firebase auth.currentUser if needed
                    const currentUser = user || auth.currentUser;
-                   
+                   // Fold in any value typed but not yet flushed on blur so the final
+                   // save can't drop the last set the user was editing.
+                   const effectiveSetData = mergeSetData(setData, pendingInputRef.current);
+
                    if (currentUser?.uid && course?.courseId) {
                      // Save only exercises that have actual user data before completing
                      for (let exerciseIndex = 0; exerciseIndex < workout.exercises.length; exerciseIndex++) {
@@ -4274,7 +4321,7 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
 
                        for (let setIndex = 0; setIndex < exercise.sets.length; setIndex++) {
                          const setKey = `${exerciseIndex}_${setIndex}`;
-                         const currentSetData = setData[setKey] || {};
+                         const currentSetData = effectiveSetData[setKey] || {};
                          allSets.push(currentSetData);
                          const hasReps = currentSetData.reps && currentSetData.reps !== '' && (!isNaN(parseFloat(currentSetData.reps)) || String(currentSetData.reps).trim().toUpperCase() === 'AMRAP');
                          const hasWeight = currentSetData.weight && currentSetData.weight !== '' && !isNaN(parseFloat(currentSetData.weight));
@@ -4295,7 +4342,7 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
                       exercises: workout.exercises.map((exercise, exerciseIndex) => {
                         const setsWithData = exercise.sets.map((set, setIndex) => {
                           const key = `${exerciseIndex}_${setIndex}`;
-                          const actualSetData = setData[key] || {};
+                          const actualSetData = effectiveSetData[key] || {};
 
                           return {
                             ...set,
@@ -4332,10 +4379,10 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
                     // This catches index-alignment bugs on the resume path.
                     if (
                       workoutWithSetData.exercises.length === 0 &&
-                      Object.values(setData).some(v => v && (v.reps || v.weight || v.time || v.distance || v.duration))
+                      Object.values(effectiveSetData).some(v => v && (v.reps || v.weight || v.time || v.distance || v.duration))
                     ) {
                       logger.error('❌ completeSession aborted: setData present but all exercises filtered out', {
-                        setDataKeys: Object.keys(setData).length,
+                        setDataKeys: Object.keys(effectiveSetData).length,
                         workoutExerciseCount: workout.exercises?.length,
                       });
                       Alert.alert(
@@ -4573,11 +4620,12 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
             restoreListViewModelScroll={restoreListViewModelScroll}
             freezeDimsForListInput={freezeDimsForListInput}
             unfreezeDimsForListInput={unfreezeDimsForListInput}
+            pendingInputRef={pendingInputRef}
           />
         </View>
       );
     });
-  }, [workout, setValidationErrors, updateSetData, restoreListViewModelScroll, freezeDimsForListInput, unfreezeDimsForListInput]);
+  }, [workout, setValidationErrors, updateSetData, restoreListViewModelScroll, freezeDimsForListInput, unfreezeDimsForListInput, pendingInputRef]);
 
   // Render function for FlatList exercise items
   const renderExerciseItem = useCallback(({ item: exercise, index: exerciseIndex }) => {
@@ -5478,24 +5526,36 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
               style={styles.menuOption}
               onPress={() => {
                 setIsMenuVisible(false);
-                handleDiscardWorkout();
-              }}
-            >
-              <View style={styles.menuOptionContent}>
-                <SvgFileRemove width={20} height={20} color="#ffffff" />
-                <Text style={styles.menuOptionText}>Salir y Descartar Entrenamiento</Text>
-              </View>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.menuOptionLast}
-              onPress={() => {
-                setIsMenuVisible(false);
                 handleEndWorkout();
               }}
             >
               <View style={styles.menuOptionContent}>
                 <SvgFileUpload width={20} height={20} color="#ffffff" />
                 <Text style={styles.menuOptionText}>Guardar y Subir Entrenamiento</Text>
+              </View>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.menuOption}
+              onPress={() => {
+                setIsMenuVisible(false);
+                handleExitKeepProgress();
+              }}
+            >
+              <View style={styles.menuOptionContent}>
+                <SvgFileUpload width={20} height={20} color="#ffffff" style={{ opacity: 0.7, transform: [{ rotate: '180deg' }] }} />
+                <Text style={styles.menuOptionText}>Salir y continuar después</Text>
+              </View>
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.menuOptionLast}
+              onPress={() => {
+                setIsMenuVisible(false);
+                handleDiscardWorkout();
+              }}
+            >
+              <View style={styles.menuOptionContent}>
+                <SvgFileRemove width={20} height={20} color="#ffffff" />
+                <Text style={styles.menuOptionText}>Salir y Descartar Entrenamiento</Text>
               </View>
             </TouchableOpacity>
           </View>

--- a/apps/pwa/src/screens/WorkoutExecutionScreen.js
+++ b/apps/pwa/src/screens/WorkoutExecutionScreen.js
@@ -839,7 +839,7 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
   if (servicesDuration > 500) {
   }
   
-  const { course: routeCourse, workout: initialWorkout, sessionId, checkpoint: routeCheckpointFromParams } = route.params;
+  const { course: routeCourse, workout: initialWorkout, sessionId, checkpoint: routeCheckpointFromParams, reopenCompletionId } = route.params;
   const { user } = useAuth();
   const { isMuted, toggleMute } = useVideo();
 
@@ -4349,7 +4349,7 @@ const WorkoutExecutionScreen = ({ navigation, route }) => {
                       currentUser.uid,
                       course.courseId,
                       workoutWithSetData,
-                      { plannedWorkout: workout, userNotes: sessionNotes }
+                      { plannedWorkout: workout, userNotes: sessionNotes, replacesCompletionId: reopenCompletionId || null }
                     );
                      
                      if (result) {

--- a/apps/pwa/src/screens/WorkoutExecutionScreen.web.jsx
+++ b/apps/pwa/src/screens/WorkoutExecutionScreen.web.jsx
@@ -48,6 +48,7 @@ const WorkoutExecutionScreen = () => {
       workout: location.state?.workout || null,
       sessionId: location.state?.sessionId || null,
       checkpoint: location.state?.checkpoint || null,
+      reopenCompletionId: location.state?.reopenCompletionId || null,
     }
   }), [location.state]);
 

--- a/apps/pwa/src/services/exerciseHistoryService.js
+++ b/apps/pwa/src/services/exerciseHistoryService.js
@@ -7,7 +7,7 @@ class ExerciseHistoryService {
    * Add session data to both exercise and session history.
    * All writes are handled server-side by POST /workout/complete.
    */
-  async addSessionData(userId, sessionData, plannedSnapshot = null) {
+  async addSessionData(userId, sessionData, plannedSnapshot = null, replacesCompletionId = null) {
     if (!sessionData || !sessionData.exercises || !Array.isArray(sessionData.exercises)) {
       throw new Error('Invalid session data structure');
     }
@@ -24,6 +24,9 @@ class ExerciseHistoryService {
       planned: plannedSnapshot ? {
         exercises: plannedSnapshot.exercises,
       } : undefined,
+      // Present only when re-finishing a reopened session: the server replaces
+      // this completion's footprint instead of appending a duplicate.
+      replacesCompletionId: replacesCompletionId || undefined,
     };
 
     const res = await apiClient.post('/workout/complete', body);

--- a/apps/pwa/src/services/purchaseService.js
+++ b/apps/pwa/src/services/purchaseService.js
@@ -95,7 +95,7 @@ class PurchaseService {
    * @param {string} payerEmail - Mercado Pago email from login
    * @returns {Promise<Object>} Checkout result
    */
-  async prepareSubscription(userId, courseId, payerEmail) {
+  async prepareSubscription(userId, courseId, payerEmail, surface) {
     try {
       if (!payerEmail) {
         return {
@@ -107,7 +107,11 @@ class PurchaseService {
 
       let result;
       try {
-        result = await apiClient.post('/payments/subscription', { courseId, payer_email: payerEmail });
+        result = await apiClient.post('/payments/subscription', {
+          courseId,
+          payer_email: payerEmail,
+          ...(surface ? { surface } : {}),
+        });
       } catch (error) {
         if (error.code === 'CAPACITY_FULL') {
           return {
@@ -134,6 +138,7 @@ class PurchaseService {
       return {
         success: true,
         checkoutURL: initPoint,
+        subscriptionId: result?.data?.subscription_id || null,
       };
     } catch (error) {
       logger.error('❌ [prepareSubscription] Exception:', error.message);
@@ -211,7 +216,7 @@ class PurchaseService {
   /**
    * Prepare a bundle subscription checkout. Always monthly recurring.
    */
-  async prepareBundleSubscription(bundleId, payerEmail) {
+  async prepareBundleSubscription(bundleId, payerEmail, surface) {
     try {
       try {
         analyticsService.track('program.purchase_started', {
@@ -232,6 +237,7 @@ class PurchaseService {
         result = await apiClient.post('/payments/bundle-subscription', {
           bundleId,
           payer_email: payerEmail,
+          ...(surface ? { surface } : {}),
         });
       } catch (error) {
         if (error.code === 'CONFLICT') {
@@ -245,7 +251,11 @@ class PurchaseService {
       }
       const initPoint = result?.data?.init_point;
       if (!initPoint) throw new Error('Error creating bundle subscription checkout');
-      return { success: true, checkoutURL: initPoint };
+      return {
+        success: true,
+        checkoutURL: initPoint,
+        subscriptionId: result?.data?.subscription_id || null,
+      };
     } catch (error) {
       return { success: false, error: error.message || 'Error preparing bundle subscription' };
     }

--- a/apps/pwa/src/services/sessionService.js
+++ b/apps/pwa/src/services/sessionService.js
@@ -403,6 +403,7 @@ class SessionService {
    * @param {Object} sessionData - Session/workout data with performed exercises
    * @param {Object} [options] - Optional options
    * @param {Object} [options.plannedWorkout] - Original workout template (before user merge) for planned snapshot
+   * @param {string} [options.replacesCompletionId] - When re-finishing a reopened session, the original completion id to replace instead of appending a new one
    */
   async completeSession(userId, courseId, sessionData, options = {}) {
     try {
@@ -440,8 +441,15 @@ class SessionService {
         ? this.buildPlannedSnapshot(options.plannedWorkout)
         : null;
 
-      // Submit session — server handles course progress, 1RM, streak atomically
-      const serverResult = await this.addSessionData(userId, actualSessionData, plannedSnapshot);
+      // Submit session — server handles course progress, 1RM, streak atomically.
+      // replacesCompletionId tells the server to replace a reopened session's
+      // footprint instead of appending a duplicate.
+      const serverResult = await this.addSessionData(
+        userId,
+        actualSessionData,
+        plannedSnapshot,
+        options.replacesCompletionId ?? null
+      );
       const personalRecords = serverResult?.personalRecords ?? [];
       if (serverResult?.completionId) {
         actualSessionData.completionDocId = serverResult.completionId;
@@ -629,15 +637,98 @@ class SessionService {
    * @param {Object} sessionData - Session data with exercises (performed)
    * @param {Object} [plannedSnapshot] - Optional snapshot of planned session at completion time
    */
-  async addSessionData(userId, sessionData, plannedSnapshot = null) {
+  async addSessionData(userId, sessionData, plannedSnapshot = null, replacesCompletionId = null) {
     try {
-      const result = await exerciseHistoryService.addSessionData(userId, sessionData, plannedSnapshot);
+      const result = await exerciseHistoryService.addSessionData(userId, sessionData, plannedSnapshot, replacesCompletionId);
       return result;
-      
+
     } catch (error) {
       logger.error('Error adding session data:', error);
       throw error;
     }
+  }
+
+  /**
+   * Find the most recent completion of a given program session on a given day.
+   * Used by the Hoy "Continuar sesión" flow to locate which completed session
+   * record to reopen. Sessions come back newest-first, so the first match wins.
+   * @returns {Promise<Object|null>} the sessionHistory record (with completionId) or null
+   */
+  async getLatestCompletionForSession(userId, courseId, sessionId, date) {
+    try {
+      const res = await apiClient.get('/workout/sessions', { params: { courseId, limit: 20 } });
+      const docs = res?.data ?? [];
+      // Sessions come back newest-first. Prefer a completion on the given date,
+      // but fall back to the most recent completion of this session so reopen
+      // still works when it was finished on an earlier day.
+      const sameSession = docs.filter((d) => d.sessionId === sessionId);
+      if (sameSession.length === 0) return null;
+      const onDate = date
+        ? sameSession.find((d) => (d.date || d.completedAt || '').slice(0, 10) === date)
+        : null;
+      const match = onDate || sameSession[0];
+      return { ...match, completionId: match.completionId || match.id };
+    } catch (error) {
+      logger.error('Error fetching latest completion for session:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Reshape a completed sessionHistory record into the checkpoint format the
+   * execution screen already understands, so reopening reuses the same recovery
+   * machinery. `completedSets` is keyed by the SAVED exercise order; the screen
+   * remaps it to the current program order by exerciseId.
+   * @param {Object} completion - sessionHistory record (performed exercises/sets)
+   * @param {Object} workout - the planned workout (for naming fallbacks)
+   * @returns {Object} checkpoint
+   */
+  buildReopenCheckpoint(completion, workout) {
+    const SKIP_FIELDS = new Set([
+      'id', 'order', 'notes', 'description', 'title', 'name',
+      'created_at', 'updated_at', 'createdAt', 'updatedAt',
+      'type', 'status', 'category', 'tags', 'metadata', 'plannedIntensity',
+    ]);
+    const savedExercises = Array.isArray(completion?.exercises) ? completion.exercises : [];
+    const completedSets = {};
+    const exercises = [];
+    savedExercises.forEach((ex, exIdx) => {
+      exercises.push({ exerciseId: ex.exerciseId || ex.id || null, exerciseName: ex.exerciseName || null });
+      const sets = Array.isArray(ex.sets) ? ex.sets : [];
+      sets.forEach((set, setIdx) => {
+        const fields = {};
+        Object.keys(set || {}).forEach((field) => {
+          if (SKIP_FIELDS.has(field)) return;
+          const v = set[field];
+          if (v === null || v === undefined || v === '') return;
+          fields[field] = typeof v === 'number' ? String(v) : v;
+        });
+        completedSets[`${exIdx}_${setIdx}`] = fields;
+      });
+    });
+
+    // The completion's stored duration is in SECONDS (named durationMs in storage
+    // but treated as seconds everywhere, e.g. analytics' duration_seconds). When
+    // it's absent/zero the timer simply resumes from 0 — sets still restore fully.
+    const elapsedSeconds = Math.max(0, Math.round(Number(completion?.durationMs ?? completion?.duration ?? 0) || 0));
+
+    return {
+      userId: completion?.userId ?? null,
+      sessionId: completion?.sessionId ?? null,
+      courseId: completion?.courseId ?? null,
+      sessionName: completion?.sessionName ?? workout?.name ?? workout?.title ?? null,
+      completedSets,
+      exercises,
+      currentExerciseIndex: 0,
+      currentSetIndex: 0,
+      elapsedSeconds,
+      userNotes: completion?.userNotes ?? '',
+      // Anchor the running timer to the already-elapsed time so it continues
+      // from where the session left off rather than restarting at zero.
+      startedAt: new Date(Date.now() - elapsedSeconds * 1000).toISOString(),
+      savedAt: new Date().toISOString(),
+      reopen: true,
+    };
   }
 
   /**

--- a/config/firebase/firestore.indexes.json
+++ b/config/firebase/firestore.indexes.json
@@ -382,6 +382,15 @@
         {"order": "DESCENDING", "queryScope": "COLLECTION"},
         {"order": "ASCENDING", "queryScope": "COLLECTION_GROUP"}
       ]
+    },
+    {
+      "collectionGroup": "subscriptions",
+      "fieldPath": "status",
+      "indexes": [
+        {"order": "ASCENDING", "queryScope": "COLLECTION"},
+        {"order": "DESCENDING", "queryScope": "COLLECTION"},
+        {"order": "ASCENDING", "queryScope": "COLLECTION_GROUP"}
+      ]
     }
   ]
 }

--- a/docs/superpowers/plans/2026-06-09-codigo-abs-niveles-backend.md
+++ b/docs/superpowers/plans/2026-06-09-codigo-abs-niveles-backend.md
@@ -1,0 +1,761 @@
+# Código ABS — Niveles (shell→planes): Plan 1 — Backend
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Que la API resuelva el contenido de un programa-shell según el nivel elegido por el usuario (`nivel → plan → módulo del mes vigente → sesiones de la semana actual`), de forma aditiva y sin romper ningún programa existente.
+
+**Architecture:** Un programa (course) puede declarar `level_plans` (mapa nivel→planId) y `levels`. El usuario guarda su nivel en `users.courses[courseId].level`. La lectura de workout, cuando el course tiene `level_plans`, lee el contenido desde `plans/{planId}` (reusando la indirección que ya usa one_on_one) eligiendo el módulo por `current_block_index` (cron mensual existente) y las sesiones por `weekIndex == weekInBlock` (computado, sin cron nuevo). Toda la lógica nueva pura vive en `functions/src/api/services/levelResolution.ts` con tests vitest; el wiring en los handlers es mínimo.
+
+**Tech Stack:** Firebase Functions (TypeScript, Node 22), Express routes en `functions/src/api/routes/`, vitest, eslint, tsc.
+
+---
+
+## Hoja de ruta (esta feature = 4 planes secuenciados, cada uno entrega software funcional)
+
+- **Plan 1 — Backend (este doc):** esquema + resolución de lectura + endpoint de nivel + enrollment + cron + allowlists de creador.
+- **Plan 2 — Plataforma de creadores:** config "Planificaciones por nivel" en el shell + selector `weekIndex` en el editor de sesión de plan.
+- **Plan 3 — PWA:** modal de nivel en Hoy (primer ingreso) + etiqueta/dropdown en el reverso del Hoy card + clave de cache con nivel.
+- **Plan 4 — Contenido/seed:** crear shell ABS + 3 planes (12 meses) + librería base + seed del año.
+
+Spec de referencia: [docs/superpowers/specs/2026-06-09-codigo-abs-niveles-design.md](../specs/2026-06-09-codigo-abs-niveles-design.md).
+
+**Verificación global del Plan 1** (correr desde la raíz del repo):
+- Tests: `npm --prefix functions run test`
+- Tipos: `npm --prefix functions run build`
+- Lint: `npm --prefix functions run lint`
+
+> `wolf-20b8b` es PRODUCCIÓN. Ningún `firebase deploy` en este plan sin confirmación explícita del usuario.
+
+---
+
+## Contrato de esquema (aditivo — referencia para todas las tareas)
+
+```
+courses/{courseId}:
+  levels?:      { options: string[], default: string }        // ej: { options:["principiante","intermedio","avanzado"], default:"principiante" }
+  level_plans?: { [levelKey: string]: string }                // levelKey -> planId
+
+users/{uid}.courses[courseId]:
+  level?: string                                              // ausente => usar course.levels.default
+
+plans/{planId}/modules/{moduleId}/sessions/{sessionId}:
+  weekIndex?: number                                          // 0..4; ausente => sesión se repite toda semana (comportamiento actual)
+```
+
+Reglas:
+- Course sin `level_plans` => comportamiento idéntico al de hoy (lee de `courses/{id}/modules`).
+- Session sin `weekIndex` => no se filtra por semana (idéntico a hoy).
+- `level` ausente en el enrollment => el read usa `course.levels.default`.
+
+---
+
+## Task 1: Helpers puros de resolución (`levelResolution.ts`)
+
+**Files:**
+- Create: `functions/src/api/services/levelResolution.ts`
+- Test: `functions/src/api/services/levelResolution.test.ts`
+
+- [ ] **Step 1: Escribir los tests que fallan**
+
+```typescript
+// functions/src/api/services/levelResolution.test.ts
+import { describe, it, expect } from "vitest";
+import {
+  resolveUserLevel,
+  resolveLevelPlanId,
+  computeWeekInBlock,
+  sessionMatchesWeek,
+} from "./levelResolution";
+
+describe("resolveUserLevel", () => {
+  const course = { levels: { options: ["principiante", "intermedio", "avanzado"], default: "principiante" } };
+  it("returns the entry level when present and valid", () => {
+    expect(resolveUserLevel(course, { level: "avanzado" })).toBe("avanzado");
+  });
+  it("falls back to course default when entry level is absent", () => {
+    expect(resolveUserLevel(course, {})).toBe("principiante");
+  });
+  it("falls back to default when entry level is not a valid option", () => {
+    expect(resolveUserLevel(course, { level: "elite" })).toBe("principiante");
+  });
+  it("returns null when course has no levels", () => {
+    expect(resolveUserLevel({}, { level: "avanzado" })).toBeNull();
+  });
+});
+
+describe("resolveLevelPlanId", () => {
+  const course = {
+    levels: { options: ["principiante", "avanzado"], default: "principiante" },
+    level_plans: { principiante: "planP", avanzado: "planA" },
+  };
+  it("maps the resolved level to its plan id", () => {
+    expect(resolveLevelPlanId(course, { level: "avanzado" })).toBe("planA");
+  });
+  it("uses the default level's plan when entry level absent", () => {
+    expect(resolveLevelPlanId(course, {})).toBe("planP");
+  });
+  it("returns null when course has no level_plans", () => {
+    expect(resolveLevelPlanId({ levels: course.levels }, { level: "avanzado" })).toBeNull();
+  });
+});
+
+describe("computeWeekInBlock", () => {
+  const day = 24 * 60 * 60 * 1000;
+  const start = Date.parse("2026-06-01T05:00:00Z");
+  it("returns 0 during the first 7 days", () => {
+    expect(computeWeekInBlock(start, start + 3 * day, 3)).toBe(0);
+  });
+  it("returns 1 in the second week", () => {
+    expect(computeWeekInBlock(start, start + 9 * day, 3)).toBe(1);
+  });
+  it("clamps to maxWeekIndex", () => {
+    expect(computeWeekInBlock(start, start + 60 * day, 3)).toBe(3);
+  });
+  it("never goes negative if now < start", () => {
+    expect(computeWeekInBlock(start, start - 5 * day, 3)).toBe(0);
+  });
+  it("returns 0 when startedAt is null", () => {
+    expect(computeWeekInBlock(null, start + 30 * day, 3)).toBe(0);
+  });
+});
+
+describe("sessionMatchesWeek", () => {
+  it("matches when weekIndex equals weekInBlock", () => {
+    expect(sessionMatchesWeek({ weekIndex: 2 }, 2)).toBe(true);
+  });
+  it("does not match a different weekIndex", () => {
+    expect(sessionMatchesWeek({ weekIndex: 1 }, 2)).toBe(false);
+  });
+  it("matches any week when weekIndex is absent (legacy)", () => {
+    expect(sessionMatchesWeek({}, 2)).toBe(true);
+    expect(sessionMatchesWeek({ weekIndex: null }, 0)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Correr los tests para verificar que fallan**
+
+Run: `npm --prefix functions run test -- levelResolution`
+Expected: FAIL ("Cannot find module './levelResolution'").
+
+- [ ] **Step 3: Implementar el módulo**
+
+```typescript
+// functions/src/api/services/levelResolution.ts
+// Pure helpers for shell->plan level resolution. No Firestore I/O here so they
+// are unit-testable. All consumers (workout read, cron) call into these.
+
+export interface CourseLevels {
+  options: string[];
+  default: string;
+}
+
+interface CourseLike {
+  levels?: CourseLevels;
+  level_plans?: Record<string, string>;
+}
+
+interface EntryLike {
+  level?: string | null;
+}
+
+/**
+ * Resolve the effective level for a user on a course.
+ * - entry.level wins if it is a valid option
+ * - otherwise course.levels.default
+ * - null when the course declares no levels (not a leveled program)
+ */
+export function resolveUserLevel(
+  course: CourseLike,
+  entry: EntryLike | null | undefined
+): string | null {
+  const levels = course.levels;
+  if (!levels || !Array.isArray(levels.options) || levels.options.length === 0) {
+    return null;
+  }
+  const chosen = entry?.level;
+  if (typeof chosen === "string" && levels.options.includes(chosen)) {
+    return chosen;
+  }
+  return levels.default;
+}
+
+/** Map the resolved level to its planId. null when the course has no level_plans. */
+export function resolveLevelPlanId(
+  course: CourseLike,
+  entry: EntryLike | null | undefined
+): string | null {
+  const level = resolveUserLevel(course, entry);
+  if (!level) return null;
+  const map = course.level_plans;
+  if (!map || typeof map !== "object") return null;
+  return map[level] ?? null;
+}
+
+const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Cohort-synced current week within the live block.
+ * weekInBlock = clamp(floor((now - startedAt)/7d), 0, maxWeekIndex)
+ */
+export function computeWeekInBlock(
+  startedAtMs: number | null,
+  nowMs: number,
+  maxWeekIndex: number
+): number {
+  if (startedAtMs === null || !Number.isFinite(startedAtMs)) return 0;
+  const raw = Math.floor((nowMs - startedAtMs) / WEEK_MS);
+  if (raw < 0) return 0;
+  if (raw > maxWeekIndex) return maxWeekIndex;
+  return raw;
+}
+
+/** A session belongs to the current week if its weekIndex matches, or if it has none (legacy). */
+export function sessionMatchesWeek(
+  session: { weekIndex?: number | null },
+  weekInBlock: number
+): boolean {
+  const wi = session.weekIndex;
+  if (wi === undefined || wi === null) return true;
+  return wi === weekInBlock;
+}
+```
+
+- [ ] **Step 4: Correr los tests para verificar que pasan**
+
+Run: `npm --prefix functions run test -- levelResolution`
+Expected: PASS (todos los `describe`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add functions/src/api/services/levelResolution.ts functions/src/api/services/levelResolution.test.ts
+git commit -m "feat(abs): pure helpers for level->plan->week resolution"
+```
+
+---
+
+## Task 2: Resolver `maxWeekIndex` de un módulo de plan (helper I/O fino + test)
+
+El read necesita saber el `weekIndex` máximo de las sesiones del módulo vigente para clampear. Lo extraemos como helper puro sobre la lista de sesiones ya leídas.
+
+**Files:**
+- Modify: `functions/src/api/services/levelResolution.ts`
+- Modify: `functions/src/api/services/levelResolution.test.ts`
+
+- [ ] **Step 1: Añadir el test que falla**
+
+```typescript
+// append to levelResolution.test.ts
+import { maxWeekIndexOf } from "./levelResolution";
+
+describe("maxWeekIndexOf", () => {
+  it("returns the highest weekIndex present", () => {
+    expect(maxWeekIndexOf([{ weekIndex: 0 }, { weekIndex: 3 }, { weekIndex: 1 }])).toBe(3);
+  });
+  it("returns 0 when no session has a weekIndex (legacy)", () => {
+    expect(maxWeekIndexOf([{}, { weekIndex: null }])).toBe(0);
+  });
+  it("returns 0 for empty input", () => {
+    expect(maxWeekIndexOf([])).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Correr y verificar que falla**
+
+Run: `npm --prefix functions run test -- levelResolution`
+Expected: FAIL ("maxWeekIndexOf is not a function").
+
+- [ ] **Step 3: Implementar**
+
+```typescript
+// append to levelResolution.ts
+/** Highest weekIndex among sessions; 0 when none declare one. */
+export function maxWeekIndexOf(sessions: Array<{ weekIndex?: number | null }>): number {
+  let max = 0;
+  for (const s of sessions) {
+    if (typeof s.weekIndex === "number" && s.weekIndex > max) max = s.weekIndex;
+  }
+  return max;
+}
+```
+
+- [ ] **Step 4: Correr y verificar que pasa**
+
+Run: `npm --prefix functions run test -- levelResolution`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add functions/src/api/services/levelResolution.ts functions/src/api/services/levelResolution.test.ts
+git commit -m "feat(abs): maxWeekIndexOf helper"
+```
+
+---
+
+## Task 3: Rama de lectura para `general + level_plans` en `GET /workout/daily`
+
+Hoy el handler ([functions/src/api/routes/workout.ts](../../../functions/src/api/routes/workout.ts) ~277) ramifica por `deliveryType`: `one_on_one` (~323), un bloque `else` "legacy low-ticket / general" (~690) que lee de `courses/{id}/modules`. Añadimos: **antes** del bloque `else` general, una rama para cuando `course.level_plans` existe, que lee de `plans/{planId}` el módulo cuyo `order == current_block_index` y filtra sesiones por `weekIndex == weekInBlock`.
+
+**Files:**
+- Modify: `functions/src/api/routes/workout.ts` (handler `GET /workout/daily`, ~688)
+
+- [ ] **Step 1: Leer el contexto del handler**
+
+Abre `functions/src/api/routes/workout.ts` y lee de la línea 277 a la 900. Identifica: la variable `course`, `courseAccess` (el entry del usuario, = `courses[courseId]`), `MAX_SESSIONS_PER_MODULE`, `toLocalDateISO`, y el bloque `else` que empieza en `// ── Legacy low-ticket / general: resolve from course modules structure ──` (~690). La rama nueva va como `else if` ANTES de ese `else`.
+
+- [ ] **Step 2: Importar los helpers**
+
+Cerca del tope de `workout.ts`, junto a los otros imports de `../services/...`, añade:
+
+```typescript
+import {
+  resolveLevelPlanId,
+  computeWeekInBlock,
+  sessionMatchesWeek,
+  maxWeekIndexOf,
+} from "../services/levelResolution";
+```
+
+- [ ] **Step 3: Insertar la rama `general + level_plans`**
+
+Reemplaza la línea `} else {` que abre el bloque legacy (~689) por `} else if (resolveLevelPlanId(course, courseAccess)) {` + el cuerpo siguiente, y deja el `} else {` legacy a continuación intacto:
+
+```typescript
+    } else if (resolveLevelPlanId(course, courseAccess)) {
+      // ── General shell with per-level plans (Código ABS) ──
+      // nivel -> plan -> módulo (mes vigente por current_block_index) -> sesiones (semana actual)
+      const planId = resolveLevelPlanId(course, courseAccess)!;
+      const currentBlockIndex = typeof course.current_block_index === "number" ?
+        course.current_block_index : null;
+
+      if (currentBlockIndex === null) {
+        res.json({ data: { hasSession: false, isRestDay: false,
+          emptyReason: "no_planning_this_week", session: null,
+          progress: { completed: 0, total: null }, allSessions: [] } });
+        return;
+      }
+
+      // Find the live month-module of this plan: order === currentBlockIndex
+      const liveModSnap = await db.collection("plans").doc(planId)
+        .collection("modules").where("order", "==", currentBlockIndex).limit(1).get();
+      if (liveModSnap.empty) {
+        res.json({ data: { hasSession: false, isRestDay: false,
+          emptyReason: "no_planning_this_week", session: null,
+          progress: { completed: 0, total: null }, allSessions: [] } });
+        return;
+      }
+      const liveMod = liveModSnap.docs[0];
+      const liveModuleId = liveMod.id;
+      const liveModuleTitle = (liveMod.data().title as string) ?? "";
+
+      // current_block_started_at lives in program_state; used for weekInBlock
+      const stateSnap = await db.collection("program_state").doc(courseId).get();
+      const startedRaw = stateSnap.exists ? stateSnap.data()?.current_block_started_at : null;
+      const startedAtMs = startedRaw && typeof startedRaw.toMillis === "function" ?
+        startedRaw.toMillis() : null;
+
+      const sessionsSnap = await db.collection("plans").doc(planId)
+        .collection("modules").doc(liveModuleId)
+        .collection("sessions").orderBy("order", "asc")
+        .limit(MAX_SESSIONS_PER_MODULE).get();
+
+      const allModSessions = sessionsSnap.docs.map((sess) => ({
+        moduleId: liveModuleId,
+        sessionId: sess.id,
+        order: sess.data().order ?? 0,
+        moduleOrder: currentBlockIndex,
+        title: (sess.data().title as string) ?? "",
+        moduleTitle: liveModuleTitle,
+        image_url: (sess.data().image_url as string) ?? null,
+        dayIndex: typeof sess.data().dayIndex === "number" ? (sess.data().dayIndex as number) : null,
+        weekIndex: typeof sess.data().weekIndex === "number" ? (sess.data().weekIndex as number) : null,
+      }));
+
+      // Filter to the current cohort week, then behave like the weekly path below.
+      const maxWeek = maxWeekIndexOf(allModSessions);
+      const weekInBlock = computeWeekInBlock(startedAtMs, Date.now(), maxWeek);
+      const weekSessions = allModSessions.filter((s) => sessionMatchesWeek(s, weekInBlock));
+
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const todayWeekdayIdx = ((today.getDay() + 6) % 7) + 1; // 1..7 Lun..Dom
+      const weekStart = new Date(today);
+      weekStart.setDate(today.getDate() - (todayWeekdayIdx - 1));
+
+      // Completions scoped to this calendar week (same reasoning as weekly path)
+      const weekStartIso = weekStart.toISOString();
+      const weekCompletedSnap = await db.collection("users").doc(auth.userId)
+        .collection("sessionHistory")
+        .where("courseId", "==", courseId)
+        .where("completedAt", ">=", weekStartIso).get();
+      completedSessionIds = new Set(
+        weekCompletedSnap.docs.map((d) => d.data().sessionId as string | undefined)
+          .filter((id): id is string => typeof id === "string" && id.length > 0)
+      );
+
+      // Content for plan sessions lives under plans/, not courses/
+      sessionCollection = "plans";
+      sessionCollectionId = planId;
+
+      const sessionsWithDate = weekSessions.map((s) => {
+        const dayIdx = s.dayIndex ?? (s.order ?? 0) + 1;
+        const date = new Date(weekStart.getTime() + (dayIdx - 1) * 86400000);
+        return { ...s, dayIndex: dayIdx, plannedDate: toLocalDateISO(date) };
+      });
+      sessionsWithDate.sort((a, b) => a.dayIndex - b.dayIndex);
+      resolvedAllSessions = sessionsWithDate.map((s) => ({
+        sessionId: s.sessionId, title: s.title, moduleId: s.moduleId,
+        moduleTitle: s.moduleTitle, order: s.order, image_url: s.image_url,
+        plannedDate: s.plannedDate,
+      }));
+
+      // Pick today's target session (matches how the weekly path selects below)
+      const todayIso = toLocalDateISO(today);
+      const todaysSession = sessionsWithDate.find((s) => s.plannedDate === todayIso) ?? null;
+      targetModuleId = todaysSession ? todaysSession.moduleId : null;
+      targetSessionId = requestedSessionId ?? (todaysSession ? todaysSession.sessionId : null);
+    } else {
+      // ── Legacy low-ticket / general: resolve from course modules structure ──
+```
+
+> Nota para el ejecutor: confirma cómo el bloque weekly existente (~801–880) setea `targetModuleId`/`targetSessionId` y el shape final de `resolvedAllSessions`, y alinea el snippet de arriba con esa convención (nombres de campos, `sessionCollection`/`sessionCollectionId`, y cómo se elige `targetSessionId` por `plannedDate === today`). El objetivo: que el resto del handler (lectura de ejercicios desde `sessionCollection/sessionCollectionId/.../sessions/{targetSessionId}`) funcione sin más cambios.
+
+- [ ] **Step 4: Verificar tipos y lint**
+
+Run: `npm --prefix functions run build`
+Expected: compila sin errores de tipo.
+Run: `npm --prefix functions run lint`
+Expected: sin errores nuevos.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add functions/src/api/routes/workout.ts
+git commit -m "feat(abs): /workout/daily resolves content via level->plan->week"
+```
+
+---
+
+## Task 4: Misma resolución en `GET /workout/session-exercises`
+
+Este endpoint ([workout.ts](../../../functions/src/api/routes/workout.ts) ~1221) lee los ejercicios de una sesión concreta. Para programas con `level_plans` debe leer desde `plans/{planId}/modules/{moduleId}/sessions/{sessionId}` (no `courses/`).
+
+**Files:**
+- Modify: `functions/src/api/routes/workout.ts` (handler `GET /workout/session-exercises`, ~1221–1453)
+
+- [ ] **Step 1: Leer el handler 1221–1453** y localizar dónde decide la colección base (`courses` vs `plans`) para leer la sesión + ejercicios. Hoy usa `courses/{courseId}/modules/{moduleId}/sessions/{sessionId}` salvo en one_on_one.
+
+- [ ] **Step 2: Insertar la resolución por nivel**
+
+Cerca del inicio del handler, después de cargar `course` y el entry del usuario (`courseAccess`/`courses[courseId]`), añade:
+
+```typescript
+const levelPlanId = resolveLevelPlanId(course, courses[courseId]);
+// When set, read session/exercises from plans/{levelPlanId} instead of courses/{courseId}
+const sessionBaseCollection = levelPlanId ? "plans" : "courses";
+const sessionBaseId = levelPlanId ?? courseId;
+```
+
+Luego reemplaza las referencias `db.collection("courses").doc(courseId)` usadas para leer la sesión/ejercicios por `db.collection(sessionBaseCollection).doc(sessionBaseId)`. (El `moduleId` viene en query/params; el cliente lo obtiene de `/workout/daily`, que ya devuelve el `moduleId` del plan.)
+
+- [ ] **Step 3: Build + lint**
+
+Run: `npm --prefix functions run build && npm --prefix functions run lint`
+Expected: compila y sin errores nuevos.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add functions/src/api/routes/workout.ts
+git commit -m "feat(abs): /workout/session-exercises reads plan content for leveled courses"
+```
+
+---
+
+## Task 5: `current-block` + `programs/:courseId/modules` resuelven el plan
+
+Las vistas de estructura/semana ([workout.ts](../../../functions/src/api/routes/workout.ts): `/current-block` ~2921, `/programs/:courseId/modules` ~2758) deben, para cursos con `level_plans`, listar los módulos/semana desde el plan del nivel del usuario en vez de `courses/{id}/modules`.
+
+**Files:**
+- Modify: `functions/src/api/routes/workout.ts` (~2758–3072)
+
+- [ ] **Step 1: Leer ambos handlers (2758–3072).**
+
+- [ ] **Step 2: En `/programs/:courseId/modules`**, después de cargar `course` y el entry del usuario, resolver:
+
+```typescript
+const levelPlanId = resolveLevelPlanId(course, (userCourses ?? {})[courseId]);
+const modulesBase = levelPlanId
+  ? db.collection("plans").doc(levelPlanId).collection("modules")
+  : db.collection("courses").doc(courseId).collection("modules");
+```
+y usar `modulesBase` donde hoy se itera `courses/{id}/modules`. El filtro de cadencia (`order <= current_block_index`) se mantiene igual.
+
+- [ ] **Step 3: En `/current-block`**, el `current_block_id/index` del shell sigue siendo la fuente del mes vigente; si necesita el título del módulo, leerlo desde `plans/{levelPlanId}/modules` (order==index) cuando haya `level_plans`.
+
+- [ ] **Step 4: Build + lint**
+
+Run: `npm --prefix functions run build && npm --prefix functions run lint`
+Expected: ok.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add functions/src/api/routes/workout.ts
+git commit -m "feat(abs): structure endpoints resolve modules from level plan"
+```
+
+---
+
+## Task 6: Endpoint `PATCH /users/me/courses/:courseId/level`
+
+**Files:**
+- Modify: `functions/src/api/routes/profile.ts`
+- Test: `functions/src/api/services/levelResolution.test.ts` (añadir validación pura) — o crear `functions/src/api/routes/profile.level.test.ts` si el handler se extrae a un helper puro.
+
+- [ ] **Step 1: Test del validador puro**
+
+Extraemos la validación a `levelResolution.ts` para testearla. Añade a `levelResolution.test.ts`:
+
+```typescript
+import { isValidLevelChoice } from "./levelResolution";
+
+describe("isValidLevelChoice", () => {
+  const course = { levels: { options: ["principiante", "avanzado"], default: "principiante" } };
+  it("accepts a declared option", () => {
+    expect(isValidLevelChoice(course, "avanzado")).toBe(true);
+  });
+  it("rejects an undeclared option", () => {
+    expect(isValidLevelChoice(course, "elite")).toBe(false);
+  });
+  it("rejects when the course has no levels", () => {
+    expect(isValidLevelChoice({}, "avanzado")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Verificar que falla**
+
+Run: `npm --prefix functions run test -- levelResolution`
+Expected: FAIL ("isValidLevelChoice is not a function").
+
+- [ ] **Step 3: Implementar el validador**
+
+```typescript
+// append to levelResolution.ts
+export function isValidLevelChoice(course: CourseLike, level: string): boolean {
+  const opts = course.levels?.options;
+  return Array.isArray(opts) && opts.includes(level);
+}
+```
+
+- [ ] **Step 4: Verificar que pasa**
+
+Run: `npm --prefix functions run test -- levelResolution`
+Expected: PASS.
+
+- [ ] **Step 5: Añadir la ruta en `profile.ts`**
+
+Junto a las otras rutas `/users/me/...`, añade (ajustando imports `db`, `validateAuth`, `WakeApiServerError`, `admin`/`FieldValue` según el patrón del archivo):
+
+```typescript
+router.patch("/users/me/courses/:courseId/level", async (req, res) => {
+  const auth = await validateAuth(req);
+  const { courseId } = req.params;
+  const level = (req.body?.level ?? "") as string;
+
+  const [userSnap, courseSnap] = await Promise.all([
+    db.collection("users").doc(auth.userId).get(),
+    db.collection("courses").doc(courseId).get(),
+  ]);
+  if (!courseSnap.exists) {
+    throw new WakeApiServerError("NOT_FOUND", 404, "Programa no encontrado");
+  }
+  const entry = (userSnap.data()?.courses ?? {})[courseId];
+  if (!entry) {
+    throw new WakeApiServerError("FORBIDDEN", 403, "No tienes acceso a este programa");
+  }
+  if (!isValidLevelChoice(courseSnap.data()!, level)) {
+    throw new WakeApiServerError("VALIDATION_ERROR", 400, "Nivel inválido", "level");
+  }
+  await db.collection("users").doc(auth.userId).update({
+    [`courses.${courseId}.level`]: level,
+  });
+  res.status(200).json({ data: { courseId, level } });
+});
+```
+
+- [ ] **Step 6: Build + lint**
+
+Run: `npm --prefix functions run build && npm --prefix functions run lint`
+Expected: ok.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add functions/src/api/routes/profile.ts functions/src/api/services/levelResolution.ts functions/src/api/services/levelResolution.test.ts
+git commit -m "feat(abs): PATCH /users/me/courses/:courseId/level"
+```
+
+---
+
+## Task 7: Enrollment preserva `level` en renovación (no lo setea en compra)
+
+**Files:**
+- Modify: `functions/src/api/services/courseAssignment.ts` (`buildCourseEntry`, ~91–134)
+
+- [ ] **Step 1: Leer `buildCourseEntry`** (~91–134). Hay dos ramas: nueva compra y renovación (preserva `purchased_at` + `completedTutorials` del entry existente).
+
+- [ ] **Step 2: En la rama de RENOVACIÓN**, preservar también `level` si existía:
+
+```typescript
+// dentro de la rama de renovación, junto a purchased_at/completedTutorials:
+...(existing.level !== undefined ? { level: existing.level } : {}),
+```
+
+No agregar `level` en la rama de nueva compra (debe quedar ausente para que el modal de primer ingreso se dispare).
+
+- [ ] **Step 3: Build + lint**
+
+Run: `npm --prefix functions run build && npm --prefix functions run lint`
+Expected: ok.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add functions/src/api/services/courseAssignment.ts
+git commit -m "feat(abs): preserve user level across subscription renewal"
+```
+
+---
+
+## Task 8: Cron gatea el avance sobre los planes de nivel
+
+`advanceMonthlyDropCourse` ([index.ts](../../../functions/src/index.ts) ~2704–2843) hoy busca el siguiente módulo publicado en `courses/{id}/modules`. Para cursos con `level_plans`, el contenido del mes vive en los planes; el cron debe avanzar al índice `current+1` solo si **los 3 planes** tienen ese mes (`order == current+1`) con `published_at != null`.
+
+**Files:**
+- Modify: `functions/src/index.ts` (`advanceMonthlyDropCourse`, ~2704–2843)
+- Test: `functions/src/api/services/levelResolution.test.ts` (lógica pura del gate)
+
+- [ ] **Step 1: Test del gate puro**
+
+Añade a `levelResolution.test.ts`:
+
+```typescript
+import { allLevelPlansPublishAt } from "./levelResolution";
+
+describe("allLevelPlansPublishAt", () => {
+  it("true only when every level plan has the index published", () => {
+    const perPlan = { principiante: true, avanzado: true };
+    expect(allLevelPlansPublishAt(perPlan)).toBe(true);
+  });
+  it("false when any level plan is missing/unpublished at the index", () => {
+    expect(allLevelPlansPublishAt({ principiante: true, avanzado: false })).toBe(false);
+  });
+  it("false for empty input", () => {
+    expect(allLevelPlansPublishAt({})).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Verificar que falla**
+
+Run: `npm --prefix functions run test -- levelResolution`
+Expected: FAIL.
+
+- [ ] **Step 3: Implementar el gate puro**
+
+```typescript
+// append to levelResolution.ts
+/** True only if every level plan reports a published next-block. */
+export function allLevelPlansPublishAt(perPlanPublished: Record<string, boolean>): boolean {
+  const vals = Object.values(perPlanPublished);
+  if (vals.length === 0) return false;
+  return vals.every(Boolean);
+}
+```
+
+- [ ] **Step 4: Verificar que pasa**
+
+Run: `npm --prefix functions run test -- levelResolution`
+Expected: PASS.
+
+- [ ] **Step 5: Ramificar el cron**
+
+En `advanceMonthlyDropCourse`, antes de la consulta a `courseRef.collection("modules")`, detectar `level_plans` en el course doc. Si existe, calcular `nextIndex = currentBlockIndex + 1` y para cada `planId` de `level_plans`, leer `plans/{planId}/modules` donde `order == nextIndex` y verificar `published_at != null`; construir `perPlanPublished` y avanzar solo si `allLevelPlansPublishAt(perPlanPublished)`. El resto (escribir `program_state` + `course.current_block_index/id`, idempotencia por `current_block_started_at`) se mantiene igual. `current_block_id` para cursos con `level_plans` puede setearse al moduleId del plan default en ese índice (solo informativo; el read usa el índice).
+
+- [ ] **Step 6: Build + lint**
+
+Run: `npm --prefix functions run build && npm --prefix functions run lint`
+Expected: ok.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add functions/src/index.ts functions/src/api/services/levelResolution.ts functions/src/api/services/levelResolution.test.ts
+git commit -m "feat(abs): monthly cron gates advance on all level plans published"
+```
+
+---
+
+## Task 9: Allowlists de creador (`level_plans`, `levels`, `weekIndex`)
+
+**Files:**
+- Modify: `functions/src/api/routes/creator.ts`
+
+- [ ] **Step 1: Localizar la allowlist de `PATCH /creator/programs/:programId`** (campos editables del course-shell) y añadir `"level_plans"` y `"levels"`. Si esa allowlist no existe explícita, añadirla validando que `level_plans` sea `Record<string,string>` y `levels` tenga `{options:string[], default:string}`.
+
+- [ ] **Step 2: Localizar las allowlists de sesión de plan** — `POST /creator/plans/:planId/modules/:moduleId/sessions` (~5083) y su `PATCH` (~5275) — y añadir `"weekIndex"` a los campos permitidos (validar `number` entero ≥ 0).
+
+- [ ] **Step 3: Build + lint**
+
+Run: `npm --prefix functions run build && npm --prefix functions run lint`
+Expected: ok.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add functions/src/api/routes/creator.ts
+git commit -m "feat(abs): allow level_plans/levels on program and weekIndex on plan sessions"
+```
+
+---
+
+## Task 10: Verificación integral del Plan 1
+
+- [ ] **Step 1: Tests**
+
+Run: `npm --prefix functions run test`
+Expected: PASS (incluye `levelResolution.test.ts` + los tests existentes de middleware).
+
+- [ ] **Step 2: Tipos**
+
+Run: `npm --prefix functions run build`
+Expected: compila limpio.
+
+- [ ] **Step 3: Lint**
+
+Run: `npm --prefix functions run lint`
+Expected: sin errores nuevos.
+
+- [ ] **Step 4: Smoke manual (sin deploy)**
+
+Con un course de prueba que tenga `level_plans` + 3 planes mínimos + `program_state.current_block_index = 0` + sesiones con `weekIndex`, verificar (emulador o staging, NO prod) que `GET /workout/daily?courseId=...` devuelve la sesión del plan correcto según `users.courses[courseId].level`, y que cambiar `level` vía `PATCH .../level` cambia el contenido servido. Documentar el resultado.
+
+- [ ] **Step 5: Confirmar antes de cualquier deploy**
+
+No correr `firebase deploy --only functions` sin go explícito del usuario (`wolf-20b8b` es prod).
+
+---
+
+## Self-review (cobertura del spec — Plan 1)
+
+- Pilar 1 (level_plans/levels/level): Tasks 1, 6, 7, 9 ✓
+- Pilar 2 (cadencia sobre planes): Task 8 ✓ (lectura por índice en Task 3)
+- Pilar 3 (weekIndex): Tasks 1, 2, 3, 9 ✓
+- Read resolution en todos los endpoints: Tasks 3 (daily), 4 (session-exercises), 5 (current-block + modules) ✓
+- Aditividad (sin level_plans/weekIndex == comportamiento actual): garantizado por los fallbacks de `resolveLevelPlanId`/`sessionMatchesWeek` ✓
+- Fuera de Plan 1 (van en Planes 2–4): UI de creador, UI de PWA, seed del contenido.

--- a/docs/superpowers/plans/2026-06-09-codigo-abs-niveles-creadores.md
+++ b/docs/superpowers/plans/2026-06-09-codigo-abs-niveles-creadores.md
@@ -1,0 +1,269 @@
+# Código ABS — Niveles: Plan 2 — Plataforma de creadores
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Que un creador pueda (a) mapear cada nivel del programa a un plan existente (`level_plans` + `levels`) desde la vista del programa-shell, y (b) marcar el `weekIndex` de cada sesión de plan en el editor.
+
+**Architecture:** Reusa el editor de planes existente (`/plans/...`, `plansService`) sin tocarlo. Añade una sección de configuración "Planificaciones por nivel" en la vista del programa (`GroupProgramView.jsx`) que escribe `levels` + `level_plans` vía `PATCH /creator/programs/:programId` (allowlist habilitada en Plan 1, Task 9). Añade un control `weekIndex` en el editor de sesión de plan. La lógica pura (normalización del mapeo nivel→plan) se testea con vitest; el wiring visual se verifica con build/lint/manual (el repo no tiene tests de render de componentes).
+
+**Tech Stack:** Vite + React 18 (JSX), `@tanstack/react-query` v5, vitest, eslint. Prereq: Plan 1 desplegado o en la misma rama (la API ya acepta `level_plans`/`levels`/`weekIndex`).
+
+**Diseño:** seguir `feedback_creator_dashboard_design` (Hick's Law, baja carga cognitiva, copy con onda, mejor manejo de errores) y `docs/STANDARDS.md`.
+
+**Verificación global:** `npm --prefix apps/creator-dashboard run test` · `npm run build:creator` · `npm --prefix apps/creator-dashboard run lint`.
+
+---
+
+## Task 1: Helper puro de normalización del mapeo nivel→plan
+
+**Files:**
+- Create: `apps/creator-dashboard/src/utils/levelPlans.js`
+- Test: `apps/creator-dashboard/src/utils/levelPlans.test.js`
+
+- [ ] **Step 1: Test que falla**
+
+```javascript
+// levelPlans.test.js
+import { describe, it, expect } from 'vitest';
+import { buildLevelConfig, isLevelConfigComplete } from './levelPlans';
+
+describe('buildLevelConfig', () => {
+  it('builds { levels, level_plans } from a mapping', () => {
+    const out = buildLevelConfig(
+      ['principiante', 'intermedio', 'avanzado'],
+      'principiante',
+      { principiante: 'p1', intermedio: 'p2', avanzado: 'p3' }
+    );
+    expect(out).toEqual({
+      levels: { options: ['principiante', 'intermedio', 'avanzado'], default: 'principiante' },
+      level_plans: { principiante: 'p1', intermedio: 'p2', avanzado: 'p3' },
+    });
+  });
+  it('omits levels with no plan selected', () => {
+    const out = buildLevelConfig(['principiante', 'avanzado'], 'principiante', { principiante: 'p1', avanzado: '' });
+    expect(out.level_plans).toEqual({ principiante: 'p1' });
+  });
+});
+
+describe('isLevelConfigComplete', () => {
+  it('true when every option maps to a plan', () => {
+    expect(isLevelConfigComplete(['a', 'b'], { a: 'p1', b: 'p2' })).toBe(true);
+  });
+  it('false when an option is unmapped', () => {
+    expect(isLevelConfigComplete(['a', 'b'], { a: 'p1', b: '' })).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Verificar que falla**
+
+Run: `npm --prefix apps/creator-dashboard run test -- levelPlans`
+Expected: FAIL (módulo no existe).
+
+- [ ] **Step 3: Implementar**
+
+```javascript
+// apps/creator-dashboard/src/utils/levelPlans.js
+export function buildLevelConfig(options, defaultLevel, mapping) {
+  const level_plans = {};
+  for (const opt of options) {
+    const planId = mapping?.[opt];
+    if (planId) level_plans[opt] = planId;
+  }
+  return { levels: { options, default: defaultLevel }, level_plans };
+}
+
+export function isLevelConfigComplete(options, mapping) {
+  return options.length > 0 && options.every((o) => !!mapping?.[o]);
+}
+```
+
+- [ ] **Step 4: Verificar que pasa**
+
+Run: `npm --prefix apps/creator-dashboard run test -- levelPlans`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/creator-dashboard/src/utils/levelPlans.js apps/creator-dashboard/src/utils/levelPlans.test.js
+git commit -m "feat(abs-creator): level-plan config helpers"
+```
+
+---
+
+## Task 2: Método de servicio para guardar la config de niveles
+
+**Files:**
+- Modify: `apps/creator-dashboard/src/services/programService.js`
+
+- [ ] **Step 1: Localizar `programService`** y confirmar el patrón de `apiClient.patch`. Añadir:
+
+```javascript
+// programService.js
+async setLevelConfig(programId, { levels, level_plans }) {
+  const res = await apiClient.patch(`/creator/programs/${programId}`, { levels, level_plans });
+  return res.data;
+}
+```
+
+> Si ya existe un `updateProgram(programId, updates)` genérico, usar ese en el componente en vez de añadir método. Confirmar y preferir reuso (DRY).
+
+- [ ] **Step 2: Lint**
+
+Run: `npm --prefix apps/creator-dashboard run lint`
+Expected: ok.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/creator-dashboard/src/services/programService.js
+git commit -m "feat(abs-creator): programService.setLevelConfig"
+```
+
+---
+
+## Task 3: Componente `LevelPlansConfig` + montaje en `GroupProgramView`
+
+**Files:**
+- Create: `apps/creator-dashboard/src/components/program/LevelPlansConfig.jsx`
+- Modify: `apps/creator-dashboard/src/components/program/GroupProgramView.jsx`
+
+- [ ] **Step 1: Leer `GroupProgramView.jsx`** y localizar dónde vive el toggle de `block_cadence` / la sección de settings del programa. La nueva sección "Planificaciones por nivel" va junto a esa.
+
+- [ ] **Step 2: Crear `LevelPlansConfig.jsx`**
+
+Comportamiento:
+- Toggle "Este programa tiene niveles" (si off → no escribe `levels`/`level_plans`; el programa se comporta como hoy).
+- Si on: lista fija de opciones `['principiante','intermedio','avanzado']`, un selector de "nivel por defecto", y por cada opción un `<select>` que lista los planes del creador (obtenidos con React Query vía `plansService.list()` — confirmar el método de listado; el agente vio `GET /creator/plans`).
+- Botón "Guardar" deshabilitado hasta `isLevelConfigComplete`; al guardar llama `programService.setLevelConfig(programId, buildLevelConfig(options, default, mapping))` dentro de un `useMutation`, con toast de éxito/error (mejor manejo de errores).
+
+```jsx
+// LevelPlansConfig.jsx (esqueleto — completar estilos según STANDARDS.md)
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import programService from '../../services/programService';
+import plansService from '../../services/plansService';
+import { buildLevelConfig, isLevelConfigComplete } from '../../utils/levelPlans';
+
+const OPTIONS = ['principiante', 'intermedio', 'avanzado'];
+
+export default function LevelPlansConfig({ programId, initial }) {
+  const qc = useQueryClient();
+  const [enabled, setEnabled] = useState(!!initial?.levels);
+  const [def, setDef] = useState(initial?.levels?.default ?? 'principiante');
+  const [mapping, setMapping] = useState(initial?.level_plans ?? {});
+
+  const { data: plans = [] } = useQuery({
+    queryKey: ['creator', 'plans'],
+    queryFn: () => plansService.list(),
+  });
+
+  const save = useMutation({
+    mutationFn: () => programService.setLevelConfig(programId, buildLevelConfig(OPTIONS, def, mapping)),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['creator', 'program', programId] }),
+  });
+
+  if (!enabled) {
+    return (
+      <button onClick={() => setEnabled(true)}>Activar niveles (planificaciones por nivel)</button>
+    );
+  }
+  return (
+    <section>
+      <h3>Planificaciones por nivel</h3>
+      {OPTIONS.map((opt) => (
+        <div key={opt}>
+          <label>{opt}</label>
+          <select value={mapping[opt] ?? ''} onChange={(e) => setMapping((m) => ({ ...m, [opt]: e.target.value }))}>
+            <option value="">— elegir plan —</option>
+            {plans.map((p) => <option key={p.id} value={p.id}>{p.title}</option>)}
+          </select>
+        </div>
+      ))}
+      <label>Nivel por defecto
+        <select value={def} onChange={(e) => setDef(e.target.value)}>
+          {OPTIONS.map((o) => <option key={o} value={o}>{o}</option>)}
+        </select>
+      </label>
+      <button disabled={!isLevelConfigComplete(OPTIONS, mapping) || save.isPending} onClick={() => save.mutate()}>
+        {save.isPending ? 'Guardando…' : 'Guardar'}
+      </button>
+      {save.isError && <p role="alert">No se pudo guardar. Reintenta.</p>}
+    </section>
+  );
+}
+```
+
+> Confirmar el método de listado de planes (`plansService.list()` o equivalente; el endpoint es `GET /creator/plans`) y el shape `{ id, title }`.
+
+- [ ] **Step 3: Montar en `GroupProgramView.jsx`** pasando `programId` y el `initial` desde el course doc ya cargado (`{ levels, level_plans }`).
+
+- [ ] **Step 4: Build + lint**
+
+Run: `npm run build:creator && npm --prefix apps/creator-dashboard run lint`
+Expected: compila y sin errores nuevos.
+
+- [ ] **Step 5: Verificación manual (dev server)**
+
+Abrir un programa de prueba, activar niveles, mapear los 3 a planes, guardar; confirmar en la BD (MCP/console) que `courses/{id}.levels` y `.level_plans` quedaron escritos.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/creator-dashboard/src/components/program/LevelPlansConfig.jsx apps/creator-dashboard/src/components/program/GroupProgramView.jsx
+git commit -m "feat(abs-creator): level->plan config UI on program shell"
+```
+
+---
+
+## Task 4: Selector de `weekIndex` en el editor de sesión de plan
+
+**Files:**
+- Modify: `apps/creator-dashboard/src/screens/PlanSessionDetailScreen.jsx`
+- Modify: `apps/creator-dashboard/src/services/plansService.js` (solo si no existe `updateSession`)
+
+- [ ] **Step 1: Leer `PlanSessionDetailScreen.jsx`** y localizar el header de la sesión donde se editan `title`/`dayIndex`. El selector `weekIndex` va ahí.
+
+- [ ] **Step 2: Añadir el control**
+
+Un `<select>` "Semana del mes" con opciones 0–4 (etiquetadas "Semana 1".."Semana 5" → value = índice) y una opción "Todas las semanas" (value vacío → no escribe `weekIndex`). Al cambiar, llama:
+
+```javascript
+await plansService.updateSession(planId, moduleId, sessionId, {
+  weekIndex: value === '' ? null : Number(value),
+});
+```
+
+> Confirmar la firma real de `plansService.updateSession` (PATCH `/creator/plans/:planId/modules/:moduleId/sessions/:sessionId`). Si no existe, añadirla siguiendo el patrón de los otros métodos del servicio.
+
+- [ ] **Step 3: Build + lint**
+
+Run: `npm run build:creator && npm --prefix apps/creator-dashboard run lint`
+Expected: ok.
+
+- [ ] **Step 4: Verificación manual**
+
+En un plan de prueba, marcar `weekIndex` de una sesión; confirmar en BD que `plans/.../sessions/{id}.weekIndex` quedó escrito.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/creator-dashboard/src/screens/PlanSessionDetailScreen.jsx apps/creator-dashboard/src/services/plansService.js
+git commit -m "feat(abs-creator): weekIndex selector on plan session editor"
+```
+
+---
+
+## Task 5: Verificación integral del Plan 2
+
+- [ ] **Step 1:** `npm --prefix apps/creator-dashboard run test` → PASS.
+- [ ] **Step 2:** `npm run build:creator` → compila.
+- [ ] **Step 3:** `npm --prefix apps/creator-dashboard run lint` → sin errores nuevos.
+- [ ] **Step 4 (manual):** flujo completo — crear/elegir 3 planes, mapearlos a niveles en un programa, marcar `weekIndex` en sus sesiones; confirmar escrituras en BD.
+
+## Self-review (cobertura del spec — Plan 2)
+- Sección "Planificaciones por nivel" (mapeo nivel→plan): Tasks 1–3 ✓
+- Selector `weekIndex`: Task 4 ✓
+- Aditivo (toggle off = comportamiento actual): Task 3 ✓
+- Reuso del editor de planes existente: no se toca (✓ por diseño)

--- a/docs/superpowers/plans/2026-06-09-codigo-abs-niveles-pwa.md
+++ b/docs/superpowers/plans/2026-06-09-codigo-abs-niveles-pwa.md
@@ -1,0 +1,264 @@
+# Código ABS — Niveles: Plan 3 — PWA (experiencia del usuario)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Que el usuario elija su nivel al primer ingreso al programa (modal en Hoy, antes de la primera sesión), vea su nivel en el reverso del Hoy card con un dropdown para cambiarlo, y que el contenido mostrado corresponda a su nivel.
+
+**Architecture:** El servidor ya resuelve el contenido por nivel (Plan 1); la PWA solo (1) detecta si falta elegir nivel y muestra un modal, (2) escribe el nivel vía `PATCH /users/me/courses/:courseId/level`, (3) muestra etiqueta + dropdown en `TodayWorkoutCard.web.jsx`, y (4) incluye el nivel en la clave de cache de `sessionService` para que cambiar de nivel refetchee. Lógica pura (gate del modal, builder de cache key) testeada con jest; el wiring visual se verifica con build/lint/manual (no hay tests de render en el repo).
+
+**Tech Stack:** Expo SDK 54 / React Native Web (JS, `.web.jsx`), React Router v6, React Query, jest, eslint. Prereq: Plan 1 (la API expone `PATCH .../level` y resuelve por nivel). Logging vía `apps/pwa/src/utils/logger.js` (no `console.log`). Strings en español. Sin emojis.
+
+**Verificación global:** `npm --prefix apps/pwa run test` · `npm --prefix apps/pwa run lint`. (Evitar `build:pwa` salvo necesidad: usa cache de Metro y puede mezclar config de entorno — ver `feedback_pwa_build_metro_cache`; si se construye, `--clear` y verificar `wolf-20b8b` en el bundle.)
+
+---
+
+## Task 1: Helper puro del gate del modal de nivel
+
+**Files:**
+- Create: `apps/pwa/src/utils/levelGate.js`
+- Test: `apps/pwa/src/__tests__/levelGate.test.js`
+
+- [ ] **Step 1: Test que falla**
+
+```javascript
+// levelGate.test.js
+import { shouldAskLevel, effectiveLevel } from '../utils/levelGate';
+
+describe('shouldAskLevel', () => {
+  const course = { levels: { options: ['principiante', 'avanzado'], default: 'principiante' } };
+  it('asks when course has levels and entry has no level', () => {
+    expect(shouldAskLevel(course, { status: 'active' })).toBe(true);
+  });
+  it('does not ask once a level is set', () => {
+    expect(shouldAskLevel(course, { status: 'active', level: 'avanzado' })).toBe(false);
+  });
+  it('does not ask for non-leveled courses', () => {
+    expect(shouldAskLevel({}, { status: 'active' })).toBe(false);
+  });
+});
+
+describe('effectiveLevel', () => {
+  const course = { levels: { options: ['principiante', 'avanzado'], default: 'principiante' } };
+  it('returns the chosen level', () => {
+    expect(effectiveLevel(course, { level: 'avanzado' })).toBe('avanzado');
+  });
+  it('falls back to default', () => {
+    expect(effectiveLevel(course, {})).toBe('principiante');
+  });
+  it('returns null when not leveled', () => {
+    expect(effectiveLevel({}, {})).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Verificar que falla**
+
+Run: `npm --prefix apps/pwa run test -- levelGate`
+Expected: FAIL.
+
+- [ ] **Step 3: Implementar**
+
+```javascript
+// apps/pwa/src/utils/levelGate.js
+export function effectiveLevel(course, entry) {
+  const opts = course?.levels?.options;
+  if (!Array.isArray(opts) || opts.length === 0) return null;
+  const chosen = entry?.level;
+  if (typeof chosen === 'string' && opts.includes(chosen)) return chosen;
+  return course.levels.default;
+}
+
+export function shouldAskLevel(course, entry) {
+  const opts = course?.levels?.options;
+  if (!Array.isArray(opts) || opts.length === 0) return false;
+  return !(typeof entry?.level === 'string' && opts.includes(entry.level));
+}
+```
+
+- [ ] **Step 4: Verificar que pasa**
+
+Run: `npm --prefix apps/pwa run test -- levelGate`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/pwa/src/utils/levelGate.js apps/pwa/src/__tests__/levelGate.test.js
+git commit -m "feat(abs-pwa): level gate + effectiveLevel helpers"
+```
+
+---
+
+## Task 2: Servicio para setear el nivel del curso
+
+**Files:**
+- Create: `apps/pwa/src/services/courseLevelService.js`
+
+- [ ] **Step 1: Implementar** (siguiendo el patrón de otros servicios que usan `apiClient`)
+
+```javascript
+// apps/pwa/src/services/courseLevelService.js
+import apiClient from './apiClient'; // confirmar la ruta real del cliente HTTP
+
+class CourseLevelService {
+  async setLevel(courseId, level) {
+    const res = await apiClient.patch(`/users/me/courses/${courseId}/level`, { level });
+    return res.data;
+  }
+}
+
+export default new CourseLevelService();
+```
+
+> Confirmar el import real del cliente HTTP (cómo lo importan otros servicios de la PWA).
+
+- [ ] **Step 2: Lint**
+
+Run: `npm --prefix apps/pwa run lint`
+Expected: ok.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/pwa/src/services/courseLevelService.js
+git commit -m "feat(abs-pwa): courseLevelService.setLevel"
+```
+
+---
+
+## Task 3: Modal de selección de nivel + montaje en Hoy
+
+**Files:**
+- Create: `apps/pwa/src/components/hoy/LevelPickerModal.web.jsx`
+- Modify: `apps/pwa/src/screens/HoyScreen.web.jsx`
+
+- [ ] **Step 1: Leer `HoyScreen.web.jsx`** para entender cómo obtiene el course activo + su entry del usuario (vía `useCoursesEnriched` y el doc de usuario). Identificar dónde montar el modal (encima del carrusel).
+
+- [ ] **Step 2: Crear `LevelPickerModal.web.jsx`**
+
+- Recibe `{ course, courseEntry, visible, onClose }`.
+- Muestra título "¿A qué nivel quieres entrenar?" + las opciones de `course.levels.options` como tarjetas (Principiante/Intermedio/Avanzado), con copy claro. Sin emojis. Estética dark cinematic (`docs/STANDARDS.md`): fade + translateY, canvas `#1a1a1a`.
+- Al elegir: `useMutation` → `courseLevelService.setLevel(course.id, level)` → al éxito invalida las queries de workout (`['workout','daily',...]`, `['preview','todaySession',...]`) y cierra. Estado de carga + error en español.
+
+- [ ] **Step 3: Montar en `HoyScreen.web.jsx`**
+
+```jsx
+import LevelPickerModal from '../components/hoy/LevelPickerModal.web.jsx';
+import { shouldAskLevel } from '../utils/levelGate';
+// ... dentro del render, para el course activo y su entry:
+const askLevel = shouldAskLevel(activeCourse, activeCourseEntry);
+// ...
+{askLevel && (
+  <LevelPickerModal course={activeCourse} courseEntry={activeCourseEntry} visible onClose={() => {}} />
+)}
+```
+
+El gate se apaga solo cuando el `PATCH` escribe el nivel y el doc de usuario se refetchea (entry.level deja de estar ausente). No permitir cerrar sin elegir en el primer ingreso (es 1 toque, sin fricción).
+
+- [ ] **Step 4: Lint**
+
+Run: `npm --prefix apps/pwa run lint`
+Expected: ok.
+
+- [ ] **Step 5: Verificación manual (pwa:dev)**
+
+Con un usuario suscrito a un course con `levels` y sin `level`: al entrar a Hoy aparece el modal; al elegir, desaparece y el card carga el contenido del plan correcto. Usar `?wake_debug=1` para logs.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/pwa/src/components/hoy/LevelPickerModal.web.jsx apps/pwa/src/screens/HoyScreen.web.jsx
+git commit -m "feat(abs-pwa): level picker modal on first program entry"
+```
+
+---
+
+## Task 4: Etiqueta de nivel + dropdown en el reverso del Hoy card
+
+**Files:**
+- Modify: `apps/pwa/src/components/TodayWorkoutCard.web.jsx`
+
+- [ ] **Step 1: Leer `TodayWorkoutCard.web.jsx`** y localizar el reverso del card (el estado "dado la vuelta" donde está "Empezar").
+
+- [ ] **Step 2: Añadir, solo cuando `effectiveLevel(course, courseEntry)` no es null:**
+- Una etiqueta del nivel actual (Principiante/Intermedio/Avanzado).
+- Un dropdown con `course.levels.options`; al cambiar → `courseLevelService.setLevel(course.id, nuevoNivel)` (vía `useMutation`) → invalidar `['workout','daily',...]` + `['preview','todaySession',...]`. Mantener cohort-sync de la semana (no reinicia `weekInBlock`; eso lo maneja el server). Estado de carga + error en español. Sin emojis.
+
+- [ ] **Step 3: Lint**
+
+Run: `npm --prefix apps/pwa run lint`
+Expected: ok.
+
+- [ ] **Step 4: Verificación manual**
+
+Voltear el card; ver la etiqueta; cambiar de nivel desde el dropdown → el contenido del card se actualiza al plan del nuevo nivel.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/pwa/src/components/TodayWorkoutCard.web.jsx
+git commit -m "feat(abs-pwa): level label + switcher on Hoy card back"
+```
+
+---
+
+## Task 5: Incluir el nivel en la clave de cache de `sessionService`
+
+**Files:**
+- Modify: `apps/pwa/src/services/sessionService.js`
+- Test: `apps/pwa/src/__tests__/sessionCacheKey.test.js` (si la construcción de la key se extrae a función pura)
+
+- [ ] **Step 1: Leer `sessionService.js`** (la cache en memoria con clave `${userId}|${courseId}[|targetDate]`, TTL 5 min).
+
+- [ ] **Step 2: Extraer la construcción de la key a una función pura y testearla**
+
+```javascript
+// dentro de sessionService.js, exportar:
+export function buildSessionCacheKey({ userId, courseId, targetDate, level }) {
+  return [userId, courseId, targetDate || '', level || ''].join('|');
+}
+```
+
+```javascript
+// sessionCacheKey.test.js
+import { buildSessionCacheKey } from '../services/sessionService';
+it('keys differ by level so switching level refetches', () => {
+  const a = buildSessionCacheKey({ userId: 'u', courseId: 'c', level: 'principiante' });
+  const b = buildSessionCacheKey({ userId: 'u', courseId: 'c', level: 'avanzado' });
+  expect(a).not.toBe(b);
+});
+```
+
+- [ ] **Step 3: Verificar que pasa**
+
+Run: `npm --prefix apps/pwa run test -- sessionCacheKey`
+Expected: PASS.
+
+- [ ] **Step 4: Usar la key con nivel** en todas las lecturas/escrituras de la cache de `sessionService`, pasando el `level` efectivo. Confirmar también que las `queryKey` de React Query relevantes (`['preview','todaySession', userId, courseId]`) incluyan el nivel donde aplique, para que cambiar de nivel invalide correctamente.
+
+- [ ] **Step 5: Lint + test**
+
+Run: `npm --prefix apps/pwa run lint && npm --prefix apps/pwa run test`
+Expected: ok / PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/pwa/src/services/sessionService.js apps/pwa/src/__tests__/sessionCacheKey.test.js
+git commit -m "feat(abs-pwa): include level in session cache key"
+```
+
+---
+
+## Task 6: Verificación integral del Plan 3
+
+- [ ] **Step 1:** `npm --prefix apps/pwa run test` → PASS (levelGate + sessionCacheKey + tests existentes).
+- [ ] **Step 2:** `npm --prefix apps/pwa run lint` → sin errores nuevos.
+- [ ] **Step 3 (manual, `npm run pwa:dev`):** primer ingreso → modal; elegir nivel → card carga plan correcto; voltear card → etiqueta + cambiar nivel → contenido cambia.
+
+## Self-review (cobertura del spec — Plan 3)
+- Modal de nivel en Hoy al primer ingreso: Tasks 1, 3 ✓
+- Etiqueta + dropdown en el reverso del card: Task 4 ✓
+- Persistencia vía `PATCH .../level`: Task 2 ✓
+- Cache key con nivel (cambiar nivel refetchea): Task 5 ✓
+- Onboarding sin cambios: no se toca (✓)

--- a/docs/superpowers/plans/2026-06-09-codigo-abs-niveles-seed.md
+++ b/docs/superpowers/plans/2026-06-09-codigo-abs-niveles-seed.md
@@ -1,0 +1,205 @@
+# Código ABS — Niveles: Plan 4 — Contenido / Seed
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Un script idempotente que crea en producción el programa-shell "Código ABS" + 3 planificaciones (Principiante/Intermedio/Avanzado), cada una con módulos-mes y sesiones marcadas por `weekIndex`+`dayIndex`, todo apuntando a una librería base de ejercicios de abdomen, dejando el shell con `levels` + `level_plans` cableados.
+
+**Architecture:** Reusa el patrón de `scripts/seed-metodo-bejarano.js` (dry-run por defecto, `--validate`, `--write`, idempotente, `NODE_PATH=functions/node_modules`). Diferencias clave para ABS: el contenido vive en `plans/{planId}` (3 planes), no en `courses/{id}/modules`; el shell solo guarda `levels` + `level_plans`; las sesiones llevan `weekIndex`. Como el manuscrito está incompleto, el script se entrega con la **estructura completa + Mes 1 autorizado para los 3 niveles** como plantilla validada y extensible (extender el array de meses a medida que Felipe complete el contenido).
+
+**Tech Stack:** Node script en `scripts/`, Firebase Admin SDK (vía `NODE_PATH=functions/node_modules`), Firestore. Builders puros testeables con vitest (en `functions`, donde está vitest) si se extraen a un módulo importable; si no, validación vía `--validate` + `--dry-run` + lectura de vuelta por MCP.
+
+> **PRODUCCIÓN.** `wolf-20b8b` es prod. El `--write` NO se corre sin confirmación explícita del usuario (`feedback_deploy_confirmation`). Todo se crea en `status: draft` / módulos sin `published_at` hasta que Felipe revise y publique desde el dashboard.
+
+**Prereqs:** Plan 1 desplegado (API resuelve por nivel) y, para probar de punta a punta, Planes 2–3. El contenido real (R22–50, nivel Intermedio, prescripciones por semana) es homework de Felipe.
+
+---
+
+## Contrato de datos que produce el seed (referencia)
+
+```
+courses/{absCourseId}  (shell)
+  title: "Código ABS", creator_id: FELIPE_UID, deliveryType: "general",
+  block_cadence: "monthly_first_monday", access_duration: "monthly",
+  subscription_price: <COP>, status: "draft", scheduling: "weekly",
+  levels: { options: ["principiante","intermedio","avanzado"], default: "principiante" },
+  level_plans: { principiante: <planP>, intermedio: <planI>, avanzado: <planA> }
+  (capacity: <n> si beta)
+
+plans/{planX}  (×3, uno por nivel)
+  title: "Código ABS — <Nivel>", creator_id: FELIPE_UID, discipline: "abdomen"
+  modules/{m}  order 0..11, title "Mes N — <tema>", published_at: null (hasta publicar)
+    sessions/{s}  title "<Enfoque>", order, dayIndex (1=Lun..), weekIndex 0..3,
+                  source_library_session_id (opcional)
+      exercises/{e}  primary:{[ABS_LIB_ID]: exId}, alternatives, measures, objectives, order
+        sets/{set}  reps, intensity "N/10", restSeconds, rep_sequence?, order, title
+
+program_state/{absCourseId}
+  current_block_index: 0, current_block_id: <planP módulo order0 id>, current_block_started_at
+```
+
+---
+
+## Task 1: Librería base de ejercicios de abdomen
+
+**Files:**
+- Create: `scripts/seed-codigo-abs-library.js`
+
+- [ ] **Step 1: Definir la lista base** (~15–20 movimientos del manuscrito: crunch suelo, crunch en cable, crunch declinado, elevación pélvica, elevaciones de piernas colgado, plancha frontal, plancha lateral, woodchopper/giro ruso, dead bug, hollow hold, ab-wheel, deslizamiento fitball, farmer walk, pallof press, sit-up, crunch inverso, v-up, bicicletas). Cada uno con `name` canónico (displayName) y campos base (`muscle_activation`, `implements`).
+
+- [ ] **Step 2: Escribir el script** que crea/asegura `exercises_library/{ABS_LIB_ID}` con esos ejercicios (idempotente por displayName), siguiendo cómo `seed-metodo-bejarano.js` lee la librería (`exercises_library/{LIB_ID}` → `buildNameToIdIndex`). Generar/fijar un `ABS_LIB_ID`. Modo dry-run por defecto, `--write` para commitear.
+
+- [ ] **Step 3: Dry-run**
+
+Run: `NODE_PATH=functions/node_modules node scripts/seed-codigo-abs-library.js`
+Expected: imprime los ejercicios que crearía, sin escribir.
+
+- [ ] **Step 4: Commit del script** (no de datos)
+
+```bash
+git add scripts/seed-codigo-abs-library.js
+git commit -m "feat(abs-seed): ABS exercise library seed script (dry-run)"
+```
+
+- [ ] **Step 5: Escribir la librería (CON confirmación del usuario)**
+
+Run (solo tras go explícito): `NODE_PATH=functions/node_modules node scripts/seed-codigo-abs-library.js --write`
+Verificar por MCP: `exercises_library/{ABS_LIB_ID}` tiene los movimientos.
+
+---
+
+## Task 2: Modelo del macro (config) + builders puros
+
+**Files:**
+- Create: `scripts/codigo-abs-macro.js` (config + builders, importable)
+- Test (opcional, recomendado): `functions/src/api/services/absMacro.test.ts` NO — el script es JS en `scripts/`. Si se quiere TDD, mover los builders puros a `scripts/codigo-abs-macro.js` y testear con un runner ligero, o validar vía `--validate`.
+
+- [ ] **Step 1: Definir la estructura del macro** como datos: por nivel, un array de 12 meses; cada mes con tema (título) y, por semana (`weekIndex` 0..3) × día (`dayIndex` 1/3/5 → enfoques A/B/C), una sesión con sus ejercicios (por `name` de la librería) + sets (con `rep_sequence`/`intensity`). Autorizar **Mes 1 para los 3 niveles** como plantilla; dejar Meses 2–12 como TODO de contenido (Felipe).
+
+```javascript
+// scripts/codigo-abs-macro.js (forma; completar contenido real con Felipe)
+const ENFOQUES = { A: 'Flexión espinal (grosor)', B: 'Oblicuos y rotación', C: 'Fuerza, densidad e isometría' };
+
+// Helper para una sesión (un día de una semana)
+function session({ title, dayIndex, weekIndex, exercises }) {
+  return { title, dayIndex, weekIndex, exercises };
+}
+function ex({ name, sets }) { return { name, sets }; }
+function set({ reps, intensity = '7/10', restSeconds = 60, repSequence = null }) {
+  return { reps, intensity, restSeconds, ...(repSequence ? { rep_sequence: repSequence } : {}) };
+}
+
+// Mes 1 — "Adaptación" (mismo esqueleto por nivel; cambian las variantes de ejercicio)
+const MES_1 = {
+  principiante: [
+    session({ title: ENFOQUES.A, dayIndex: 1, weekIndex: 0, exercises: [
+      ex({ name: 'Elevación pélvica - rodillas al pecho', sets: [set({ reps: '10-12' }), set({ reps: '10-12' }), set({ reps: '10-12' })] }),
+      ex({ name: 'Crunch suelo', sets: [set({ reps: '12-15' }), set({ reps: '12-15' }), set({ reps: '12-15' })] }),
+      ex({ name: 'Plancha frontal', sets: [set({ reps: '40s', intensity: null }), set({ reps: '40s', intensity: null })] }),
+    ]}),
+    // ... weekIndex 0 días B(3)/C(5); luego weekIndex 1..3 (progresión + variantes)
+  ],
+  intermedio: [ /* ... */ ],
+  avanzado: [
+    session({ title: ENFOQUES.A, dayIndex: 1, weekIndex: 0, exercises: [
+      ex({ name: 'Elevaciones de piernas colgado', sets: [set({ reps: '10-12' }), set({ reps: '10-12' }), set({ reps: '10-12' })] }),
+      ex({ name: 'Crunch en cable', sets: [set({ reps: '12-15' }), set({ reps: '12-15' }), set({ reps: '12-15' })] }),
+      ex({ name: 'Plancha frontal antebrazos altura de ojos', sets: [set({ reps: '40s', intensity: null }), set({ reps: '40s', intensity: null })] }),
+    ]}),
+  ],
+};
+
+const MACRO = {
+  principiante: [{ monthIndex: 0, title: 'Mes 1 — Adaptación', sessions: MES_1.principiante }],
+  intermedio:   [{ monthIndex: 0, title: 'Mes 1 — Adaptación', sessions: MES_1.intermedio }],
+  avanzado:     [{ monthIndex: 0, title: 'Mes 1 — Adaptación', sessions: MES_1.avanzado }],
+};
+
+module.exports = { MACRO, ENFOQUES };
+```
+
+- [ ] **Step 2: Validar resolución de nombres** — un modo `--validate` (como en el seed del Método) que confirma que cada `name` del macro existe en `exercises_library/{ABS_LIB_ID}`.
+
+Run: `NODE_PATH=functions/node_modules node scripts/seed-codigo-abs.js --validate`
+Expected: "✓ all exercise references resolve to library IDs" (tras Task 3).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/codigo-abs-macro.js
+git commit -m "feat(abs-seed): macro config + builders (Mes 1 template, 3 niveles)"
+```
+
+---
+
+## Task 3: Script de seed del shell + 3 planes
+
+**Files:**
+- Create: `scripts/seed-codigo-abs.js`
+
+- [ ] **Step 1: Escribir el script** (modelado en `seed-metodo-bejarano.js`):
+  1. `buildNameToIdIndex()` desde `exercises_library/{ABS_LIB_ID}`.
+  2. `--validate`: verifica todos los `name` del MACRO (Task 2).
+  3. Crear/asegurar el **shell course** "Código ABS" (idempotente por título+creator): `general`, `monthly_first_monday`, `access_duration: monthly`, `scheduling: "weekly"`, `subscription_price`, `status: draft`, `levels: {options:[...], default:'principiante'}`.
+  4. Para cada nivel: crear un `plans/{planId}` ("Código ABS — <Nivel>"); por cada mes del MACRO crear `modules/{m}` (`order = monthIndex`, `title`, `published_at: null`); por cada sesión crear `sessions/{s}` con `title`, `order`, `dayIndex`, **`weekIndex`**; por cada ejercicio crear `exercises/{e}` con `primary: {[ABS_LIB_ID]: nameToId.get(name)}`, `measures`, `objectives`, `order`; por cada set crear `sets/{set}` con `reps`, `intensity`, `restSeconds`, `rep_sequence?`, `order`, `title`.
+  5. Escribir `level_plans: { principiante, intermedio, avanzado }` en el shell con los IDs de los planes creados.
+  6. Idempotente: re-correr no duplica (skip por título de plan/curso ya existente; upsert de módulos por `order`).
+  7. Dry-run por defecto; `--write` para commitear.
+
+- [ ] **Step 2: Dry-run**
+
+Run: `NODE_PATH=functions/node_modules node scripts/seed-codigo-abs.js`
+Expected: imprime el árbol que crearía (1 course shell + 3 planes × 1 mes × N sesiones), sin escribir.
+
+- [ ] **Step 3: Commit del script**
+
+```bash
+git add scripts/seed-codigo-abs.js
+git commit -m "feat(abs-seed): shell + 3 level plans seed script (dry-run)"
+```
+
+---
+
+## Task 4: program_state inicial (Mes 1 vigente)
+
+**Files:**
+- Modify: `scripts/seed-codigo-abs.js` (flag `--seed-state`)
+
+- [ ] **Step 1: Añadir** la creación de `program_state/{absCourseId}` con `current_block_index: 0`, `current_block_id` = id del módulo `order 0` del plan default, `current_block_started_at` = ahora (BOG), para que Mes 1 quede vigente sin esperar al cron. Solo bajo `--write --seed-state`.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/seed-codigo-abs.js
+git commit -m "feat(abs-seed): optional program_state seed (Mes 1 live)"
+```
+
+---
+
+## Task 5: Ejecución en producción (CON confirmación) + verificación
+
+- [ ] **Step 1: Validar**
+
+Run: `NODE_PATH=functions/node_modules node scripts/seed-codigo-abs.js --validate`
+Expected: todas las referencias resuelven.
+
+- [ ] **Step 2: Confirmar con el usuario** antes de escribir (prod). Recordar: queda en `draft`, sin `published_at`.
+
+- [ ] **Step 3: Escribir (solo tras go explícito)**
+
+Run: `NODE_PATH=functions/node_modules node scripts/seed-codigo-abs.js --write`
+y, si se quiere Mes 1 vigente para QA: `... --write --seed-state`.
+
+- [ ] **Step 4: Verificar por MCP/console**
+  - `courses/{absCourseId}`: `levels` + `level_plans` (3 IDs), `status: draft`.
+  - `plans/{planP|planI|planA}`: 1 módulo (`order 0`), sesiones con `weekIndex` + `dayIndex`, ejercicios con `primary`, sets con `rep_sequence`.
+  - Punta a punta (con Planes 1–3): suscribir un usuario de prueba, elegir nivel en Hoy, confirmar que el card carga el plan correcto y que cambiar de nivel cambia el contenido.
+
+- [ ] **Step 5: NO publicar** (`status` y `published_at`) hasta que Felipe revise y complete Meses 2–12 + nivel Intermedio. La publicación se hace desde el dashboard (Plan 2) o un script aparte, con confirmación.
+
+## Self-review (cobertura del spec — Plan 4)
+- Shell ABS con `levels` + `level_plans`: Task 3 ✓
+- 3 planes con módulos-mes + sesiones `weekIndex`/`dayIndex` + ejercicios/sets: Tasks 2–3 ✓
+- Librería base reusada por los 3 planes: Task 1 ✓
+- `program_state` para Mes 1 vigente: Task 4 ✓
+- Idempotente, dry-run/validate/write, prod con confirmación, todo draft: Tasks 3–5 ✓
+- Contenido R22–50 / Intermedio completo = homework de Felipe (fuera del código): documentado ✓

--- a/docs/superpowers/specs/2026-06-04-transparent-subscription-checkout-design.md
+++ b/docs/superpowers/specs/2026-06-04-transparent-subscription-checkout-design.md
@@ -1,0 +1,203 @@
+# Transparent Subscription Checkout (MercadoPago Bricks) — Design
+
+- **Date:** 2026-06-04
+- **Status:** Approved design, pre-implementation
+- **Scope:** Web only · subscriptions only · native frozen
+
+---
+
+## Problem
+
+Subscription checkouts break a lot. We create a MercadoPago **PreApproval** with a pre-bound `payer_email` (the user's Wake account email), `status: "pending"`, and redirect the user to MercadoPago's hosted page (`init_point`). MercadoPago **requires the email/account the user authorizes with to match that pre-bound `payer_email`**. Many users' real MercadoPago account email differs from their Wake email, so the flow dies at the end — on MercadoPago's page.
+
+A reactive "enter your MercadoPago email" recovery exists (the 409 `requireAlternateEmail` path + alt-email modal), but it only fires when MercadoPago rejects at **PreApproval creation**. The common failure happens **after redirect, on MercadoPago's hosted page**, which our code cannot intercept. That's why it's frequent despite the existing recovery.
+
+### Root cause
+The failure is intrinsic to the **redirect + MercadoPago-account-login** model. We cannot know a user's MercadoPago account email ahead of time, and we cannot force them to log into the matching account. Any fix that keeps the hosted redirect can only *reduce* failures, not eliminate them.
+
+## Decision
+
+Switch **web** subscription creation to MercadoPago's **transparent card flow**:
+
+- The **Card Payment Brick** (Bricks) renders a card form in MercadoPago's hosted iframe fields, tokenizes the card **in-browser**, and returns a single-use `card_token_id`. Card data never touches our Cloud Functions.
+- The backend creates the PreApproval with that `card_token_id` and `status: "authorized"`. No redirect, no MercadoPago login.
+- `payer_email` becomes a non-blocking label (we use the account email). **The email-match wall ceases to exist.**
+
+Locked sub-decisions:
+- **Card form:** Card Payment Brick (handles tokenization, validation, installments). **3-D Secure handling is NOT assumed** — see the 3DS go/no-go gate below; it is the first thing we prove on staging, before any UI is built.
+- **Grant path:** unchanged webhook as the single source of truth + poll of the existing `/public/checkout/status`. Authorization is synchronous, but **access timing differs by trial state** (see "Grant path & timing" below) — non-trial access can lag the first-payment webhook by up to ~1 hour.
+- **Native:** frozen — keeps the redirect + existing alt-email modal. No stopgap this phase. (Native opens the MercadoPago `init_point` in `EpaycoWebView` — a legacy-named generic webview, *not* the ePayco processor — so native still routes through the same `/payments/*` endpoints. The additive framing holds.)
+
+## Scope
+
+**In scope (web):**
+- PWA web subscription purchase (`CourseDetailScreen` + `BundleDetailScreen`).
+- Landing storefront subscription purchase (`CreatorProgramDetailScreen`).
+
+**Out of scope:**
+- One-time payments (no email-match problem; guest checkout already works).
+- Native iOS/Android (frozen; redirect flow untouched).
+- MercadoPago provider migration.
+
+## Architecture
+
+The landing storefront is web-only, so `/public/checkout/start` (subscription mode) can switch fully. The PWA endpoints are called by **both** PWA-web and PWA-native, so they must support both modes:
+
+> **`card_token_id` is a new optional field on the existing endpoints.**
+> - Present → transparent authorized flow (web).
+> - Absent → existing redirect flow, byte-for-byte unchanged (native + web fallback).
+
+This keeps the change **purely additive**. Even deployed to production, current behavior is identical until a client deliberately sends a token.
+
+Affected endpoints:
+- `/payments/subscription` — PWA, single course ([functions/src/api/routes/payments.ts](../../../functions/src/api/routes/payments.ts) ~L287)
+- `/payments/bundle-subscription` — PWA, bundles (~L543)
+- `/public/checkout/start` (subscription mode) — landing ([functions/src/api/routes/public.ts](../../../functions/src/api/routes/public.ts) ~L617)
+
+## Backend changes
+
+For each endpoint, add a `card_token_id` branch:
+
+```ts
+result = await preapproval.create({ body: {
+  payer_email: buyerEmail,            // account email — now just a label, no match required
+  card_token_id: body.card_token_id,  // NEW
+  reason, external_reference,
+  auto_recurring: { /* identical to today, incl. free_trial */ },
+  status: "authorized",               // was "pending"
+  notification_url,
+  // NEW fraud signals — see "Fraud signal" below. The hosted page collected
+  // these automatically; the transparent flow must send them explicitly.
+  ...{device_id: body.device_id},     // MP device session fingerprint from the client
+  // additional_info / payer details sent on the call for risk scoring
+}});
+```
+
+- Returns **synchronously**: `{ data: { authorized: true, subscriptionId } }` — no `init_point`.
+- The Firestore subscription doc is written exactly as today (same fields, `status: "pending"` until the webhook confirms, `free_trial_days`, `next_billing_date`, etc.).
+- **New failure mode:** card declined / 3DS failed → return **`400` with a defined code (`CARD_DECLINED`, non-retryable)** and a Spanish message the form renders inline. (Avoids `402`, which is not in the project's standard HTTP error table — CLAUDE.md lists 400/401/403/404/409/429/500/503. If we prefer `402`, add it to that table explicitly first.) No email-mismatch branch on the card path.
+- **Double-submit idempotency (new requirement):** the redirect flow dedupes recent pending rows (the CR-6 guard in `public.ts`); the synchronous authorized path has **no equivalent** and a fast double-submit or double-firing token callback could create **two authorized PreApprovals = double charge**. Add a server-side idempotency key (e.g. `userId+courseId+token`) plus disable-on-submit on the client.
+- The existing `card_token_id`-absent branch (redirect, 409 alt-email string-matching) is **left intact** for native.
+
+### Fraud signal (must-have, new)
+
+The hosted redirect page collected MercadoPago's **device session fingerprint** and ran full hosted fraud screening automatically. The transparent flow does **not** — we must replicate it or ship blind to fraud signal (which our production dig associates with a real `high_risk` rejection tail):
+
+- Load MercadoPago's **device fingerprint script** on the card page and pass the resulting **`device_id`** to the endpoint, which forwards it on `preapproval.create`.
+- Send **`additional_info` (payer)** on the authorized call for risk scoring.
+- Treat this as **in scope, not optional** — it directly affects approval rates.
+
+## Frontend changes
+
+PWA (Expo→web) and landing (Vite) are separate builds, so the card form is implemented **once per app** (same pattern, two thin integrations — not literally shared):
+
+- Load **MercadoPago.js** + the **device fingerprint script**; mount the **Card Payment Brick**, styled to match Wake.
+- **Recurring-consent disclosure (new, required):** before the user authorizes, the form must clearly disclose the **recurring nature, amount, billing frequency, and how to cancel**, and capture **explicit affirmative consent** with a stored record. Leaving MercadoPago's hosted page means we lose its consent artifact; under Colombian consumer law (Ley 1480, Estatuto del Consumidor) this disclosure + consent is a legal requirement, and it's also a trust/conversion element. This is part of frontend scope.
+- On token callback → POST with `card_token_id` (+ `device_id`) → on success, show inline confirmation, then poll `/public/checkout/status` until access lands. The poll must **degrade gracefully** for non-trial subs whose first-payment webhook lags (show "Tu pago se está procesando, te avisaremos" instead of an endless spinner — see "Grant path & timing").
+- **Retry contract (new):** MercadoPago `card_token` is **single-use and expires in ~7 days**. On a decline, the same token **cannot** be reused — the Brick must **re-tokenize** before any resubmit, or a "retry" button silently fails. Wire the retry to re-create the token.
+- **PWA web:** new `.web.jsx` card-form component used by `CourseDetailScreen` + `BundleDetailScreen` on web; native keeps `EpaycoWebView` + alt-email modal.
+- **Landing:** card form replaces the redirect in `CreatorProgramDetailScreen`; `needsAltEmail` modal removed there.
+
+### Feature flag (default OFF)
+The new web card form is gated behind a flag following the existing `?wake_debug=1` / `localStorage.WAKE_DEBUG` pattern — e.g. `?wake_card=1` / `localStorage.WAKE_CARD_CHECKOUT`. Real users keep the redirect flow until we deliberately flip it on. This is the primary runtime safety net.
+
+## Grant path & timing (verify, don't assume)
+
+Access is granted by the existing webhook (single source of truth), but timing depends on trial state — verified in [payments.ts:978](../../../functions/src/api/routes/payments.ts):
+
+- **Trial subs:** access is granted **synchronously** when the `subscription_preapproval` webhook reports `status: "authorized"` — flips within seconds. Good.
+- **Non-trial subs:** there is **no** authorized-time grant; access depends on the **first-payment webhook**, which MercadoPago may fire **up to ~1 hour after authorization**. So a non-trial user can authorize successfully and then watch the poll spin.
+
+Implications:
+- Do **not** claim "access within seconds" for non-trial. The poll must degrade gracefully (processing message + we-will-notify, not an endless spinner).
+- This is a **real unknown to validate on staging**, not a formality — confirm the actual first-payment latency for non-trial authorized PreApprovals and decide whether we need an authorized-time optimistic grant for non-trial (deferred unless the lag proves bad).
+
+## What's removed (web only)
+- Landing: `needsAltEmail` modal + retry path in `CreatorProgramDetailScreen`.
+- PWA web: `showEmailModal` path in `CourseDetailScreen` (kept for native).
+- Backend 409 string-matching: **kept** (native), never hit on the card path.
+
+## Recurring logic preservation (must-not-break)
+
+The recurring engine is entirely MercadoPago's, driven by the PreApproval's `auto_recurring` config — **identical in both flows**. The resulting authorized PreApproval is indistinguishable to MercadoPago and to our webhook from a redirect-created one. Only `status` and `card_token_id` differ at creation.
+
+**Untouched:**
+- All webhook handlers (`subscription_preapproval`, payment events): `external_reference → userId` matching, access grants, trial→paid transition, `processed_payments` idempotency.
+- `auto_recurring` shape, free-trial config, 30-day rolling access, monthly-drop gate, cancellation.
+
+**Proven by:** additive code (redirect path unchanged) + staging regression test confirming a card-token subscription produces the same subscription doc, the same webhook events, and the same access grant as a redirect one — and that the redirect path still works.
+
+## Security / PCI
+
+Card data is tokenized in MercadoPago's hosted iframe fields and never reaches our Cloud Functions. PCI scope stays minimal (effectively **SAQ A**, self-attestation — no third-party audit). We take on client-side flow ownership (form, declines, and — pending the Phase 0 gate — 3DS results). MercadoPago.js must be loaded from MercadoPago's CDN (never self-hosted) to preserve this.
+
+## Money flow (unchanged)
+
+- **Charge:** first charge processes immediately and synchronously on authorization (or after the trial), same as today.
+- **Settlement/payout:** a property of the MercadoPago account, not the integration. Same account, same release schedule. **No change.**
+- **Customer statements:** the validation micro-charge + reversal (and the first charge) can appear on the customer's card statement — pre-empt the "¿por qué me cobraron?" support ticket with clear copy on the confirmation screen.
+
+## Prerequisites & account state (verify, don't assume)
+
+1. **Card processing via API enabled** (Colombia) — confirm in the MercadoPago dashboard. The redirect flow already processes cards on this account, so likely already on; 2-minute check.
+2. **Seller-account maturity** — our production `/users/me` dig found the MercadoPago account is `mercadopago_account_type: personal`, `user_type: eventual`, `required_action: simple_registration`, `billing.allow: false` (address pending). This immaturity plausibly drives the observed `high_risk` rejections and could depress the authorized-card flow's approval rate. **Complete account verification in parallel** — it's independent of the build and possibly the cheapest approval-rate win available.
+
+## Isolation & rollout strategy
+
+Three independent safety layers:
+
+1. **Code isolation:** dedicated branch in a **git worktree**; `main` stays clean; nothing lands on `main` until proven.
+2. **Runtime isolation:** backend additive (`card_token_id` optional) + web UI behind a default-OFF feature flag. Production behavior unchanged even after deploy until we flip the flag.
+3. **Payment isolation:** test on the **wake-staging** Firebase project with **MercadoPago TEST credentials** (test access token + test cards simulating approved / declined / 3DS). Production project (`wolf-20b8b`) is never touched until verified. (See `reference_staging_runbook.md`.)
+
+## Phase 0 — 3-D Secure go/no-go gate (FIRST task, blocking)
+
+Before building any UI, prove whether a **3DS challenge can be escalated and completed** when the card token is consumed by `preapproval.create` with `status: "authorized"`.
+
+### Research finding (2026-06-05) — strong NO-GO signal, empirical test still required
+
+Two independent research passes (official docs + SDK source + community) converged:
+
+- **The MercadoPago Node SDK's `PreApprovalRequest` type has NO 3DS fields.** Its complete body is `auto_recurring`, `back_url`, `card_token_id`, `external_reference`, `payer_email`, `preapproval_plan_id`, `reason`, `status` — no `three_d_secure_mode`, no challenge/`action_required`/`pending_challenge`. (`mercadopago/sdk-nodejs`, `src/clients/preApproval/commonTypes.ts`.)
+- **3DS is documented only on `POST /v1/payments`** (Checkout API / Bricks), using params (`three_d_secure_mode`, `capture`, `binary_mode`) that **don't exist on `/preapproval`**. The challenge response (`status: pending`, `status_detail: pending_challenge`, `three_ds_info.external_resource_url`) is a payments-only surface.
+- The subscription `authorized` flow validates the card via an automatic **minimum-amount validation charge**; subscription rejection handling is documented as `status_detail` reasons (e.g. `cc_rejected_high_risk`) with a 4-attempt recycle — **not** a recoverable challenge. Inference: a 3DS-mandating card likely returns `cc_rejected_*`, not a completable challenge.
+- The most-referenced LATAM community example (goncy) builds subscriptions with the **hosted redirect** (`status: pending` + `init_point`), sidestepping transparent 3DS entirely.
+
+Both passes stress this is **inference from silence** — no source explicitly says "preapproval can't do 3DS." So we still run the empirical test (harness in `/poc`), but expectations should be set to **likely NO-GO**.
+
+### The gate
+
+- **Go:** the validation charge with a 3DS-forcing test card either authorizes (frictionless) or returns a completable challenge → proceed with the full build.
+- **No-go (expected):** the 3DS-forcing card rejects (`cc_rejected_*`) with no challenge path → the clean transparent approach is not viable for 3DS-mandating Colombian issuers. Move to the fallback decision below.
+
+### If NO-GO — fallback options (each has a real cost; decide deliberately)
+
+1. **Hosted redirect, kept** — `status: pending` + `init_point`; MercadoPago owns 3DS. **But this reintroduces the original email-match problem** we set out to kill. Net: no progress on the core issue.
+2. **`/v1/payments` (3DS-capable) + self-managed recurrence** — authenticate the first charge via Bricks (which *does* support the 3DS challenge), then run recurrence ourselves by storing the card (Customer + Cards API) and charging monthly via our own scheduler. **Eliminates the email problem AND keeps 3DS — but we take over recurring billing** (a cron charging saved cards, dunning, retries), losing the "recurrence is MercadoPago's job" guarantee. Significantly larger and riskier.
+3. **Provider reconsideration** — out of scope here, but CLAUDE.md already notes MercadoPago is slated for future replacement; a NO-GO is a data point for that timeline.
+
+This gate decides whether the whole approach is viable, and if not, which fallback we accept.
+
+## Testing matrix (staging, MP test cards)
+
+- Approved card → authorized → webhook → access granted.
+- Declined card → inline Spanish error, no PreApproval orphaned.
+- 3-D Secure challenge card → Bricks challenge → success.
+- Subscription **with** free trial → no immediate charge, trial access granted, next-charge scheduled.
+- Subscription **without** trial → immediate first charge.
+- Bundle subscription path.
+- Landing path + PWA web path.
+- **Double-submit:** rapid resubmit / double-firing token callback creates exactly **one** authorized PreApproval (idempotency guard holds).
+- **Retry:** after a decline, retry re-tokenizes (single-use token not reused) and succeeds.
+- **Consent:** the recurring-disclosure consent record is stored on authorization.
+- **Fraud signal:** `device_id` + `additional_info` reach `preapproval.create`; compare approval/`high_risk` rates vs the redirect baseline.
+- **Regression:** redirect path (`card_token_id` absent) still works unchanged.
+- Confirm `auto_recurring` set identically to the redirect flow; confirm subscription doc + webhook events + grant match.
+
+## Open questions / risks
+
+- **3-D Secure on the preapproval path — the #1 risk.** Resolved by the Phase 0 go/no-go gate above; not assumed handled. (Resolves the earlier locked-vs-open contradiction: 3DS is *unproven* until Phase 0 passes.)
+- **Non-trial first-payment latency** — validate the real lag on staging (see "Grant path & timing"); decide if an authorized-time optimistic grant is needed for non-trial.
+- **Seller-account maturity** — pursue verification in parallel (see Prerequisites); may be the largest approval-rate lever.
+- MercadoPago account card-API enablement — verify before staging test.
+- Exact synchronous response contract for the confirmation screen (success copy + poll timing + processing-fallback copy) — finalize during implementation.

--- a/docs/superpowers/specs/2026-06-05-proactive-subscription-email-design.md
+++ b/docs/superpowers/specs/2026-06-05-proactive-subscription-email-design.md
@@ -1,0 +1,70 @@
+# Proactive Subscription Email + Funnel Logging — Design (minimal build)
+
+- **Date:** 2026-06-05
+- **Status:** Implemented on branch `feat/proactive-subscription-email`; pending staging test + deploy
+- **Relationship:** Near-term mitigation. The full fix (transparent card form) is deferred pending the 3DS gate — see `2026-06-04-transparent-subscription-checkout-design.md`.
+
+## Goal
+
+Reduce subscription-checkout failures caused by the MercadoPago email/account mismatch, and instrument the funnel so that in ~2 days we can measure where it still breaks.
+
+This does **not** eliminate the problem (the redirect still requires logging into a matching MercadoPago account) — it mitigates it by setting the right `payer_email` up front and telling the user which email to use.
+
+## Scope
+
+- **In:** proactive email step + funnel logging on **all three** subscription surfaces — PWA web (`CourseDetailScreen`, `BundleDetailScreen`), PWA native (same screens, RN modal), landing storefront (`CreatorProgramDetailScreen`).
+- **Out:** one-time payments; the card-token/Bricks flow; any change to recurring billing, webhooks, or access grants.
+
+## UX — one-tap confirm
+
+Before initiating the subscription redirect (replacing the current *reactive* alt-email modal with a *proactive* step):
+
+- Show the user's email prominently.
+- Primary action: **"Continuar con este correo"** (one tap → proceeds with that email).
+- Secondary action: **"Usar otro correo de Mercado Pago"** → reveals an email input.
+- Instruction copy (always visible): **"Usa este mismo correo al iniciar sesión en Mercado Pago para completar tu suscripción."**
+- The chosen email is sent as `payer_email` to the existing endpoints. No backend logic change beyond logging.
+- The existing reactive 409 `requireAlternateEmail` path stays as a safety net (if MP still rejects at creation, we re-prompt).
+
+Copy must follow Wake rules: Spanish, no emojis, no banned negation/contrast patterns.
+
+## Data flow (unchanged except email source)
+
+`email step → payerEmail → /payments/subscription | /payments/bundle-subscription | /public/checkout/start` → existing PreApproval creation → redirect → existing webhook → existing access grant. Nothing downstream changes.
+
+## Observability contract (the point of this build)
+
+One correlation id ties the funnel together: the **`subscriptionId`** (MP PreApproval id) where available, and the **`external_reference`** (`v1|{userId}|{courseId}|sub`) everywhere it isn't yet.
+
+### Client (PWA `logger` + PostHog `analyticsService`; landing logger)
+- `subscription.email_step.shown` — `{ courseId, surface }`
+- `subscription.email_step.choice` — `{ courseId, surface, choice: "account" | "custom", emailsDiffer: boolean }`
+- `subscription.checkout.redirected` — `{ courseId, surface, subscriptionId }`
+- `subscription.checkout.returned` — `{ courseId, surface }` (fired on the post-payment / status screen)
+
+Emails are never logged raw — only `emailsDiffer` and a redacted form.
+
+### Backend (`functions.logger`, structured)
+- On creation attempt: `subscription.create.attempt` — `{ userId, courseId, emailType: "account" | "custom", payerEmail: redacted, surface }`
+- On success: `subscription.create.ok` — `{ userId, courseId, subscriptionId, emailType }`
+- On MP failure: `subscription.create.fail` — `{ userId, courseId, emailType, mpStatus, mpMessage }` (extend the existing alt-email catch so we capture the MP error string/status, not just the alt-email branch).
+- Webhook transition: `subscription.webhook.status` — `{ subscriptionId, userId, courseId, from, to, trialDays }` logged on every `subscription_preapproval` status change, especially the `pending → authorized` one.
+
+### The key derived metric
+Subscriptions logged at `create.ok` (status `pending`) that **never** log a `webhook.status … to: "authorized"` within ~30 min ≈ failed/abandoned on MercadoPago's page. That count, split by `emailType`, is the verification: did sending the right email up front reduce the `pending`-stranded rate?
+
+## What's explicitly NOT changing
+- PreApproval `auto_recurring`, trials, `external_reference` format.
+- Webhook matching, access grants, idempotency, `processed_payments`.
+- One-time payment flow.
+
+## Rollout & safety
+- Purely additive (new UI step + log lines). No schema changes.
+- Test on **wake-staging** first (subscription create + webhook logs appear; redirect still works), then deploy to production with explicit confirmation (wolf-20b8b is production).
+- No feature flag: this is a strict improvement over the current reactive flow and low-risk. (If preferred, it can be flag-gated — call it out before deploy.)
+
+## Verification plan (run in ~2 days)
+1. PostHog: funnel `email_step.shown → choice → redirected → returned`, split by `choice`.
+2. Functions logs: ratio of `create.ok` to `webhook … authorized`, split by `emailType` — the stranded-at-pending rate.
+3. `create.fail` grouped by `mpMessage`/`mpStatus` — what MercadoPago errors still occur and how often.
+4. Decision input: if `custom`-email choosers strand far less than `account`-email choosers, the mitigation works; if everyone still strands at similar rates, escalate to the card-form / self-managed-recurrence decision.

--- a/docs/superpowers/specs/2026-06-09-codigo-abs-niveles-design.md
+++ b/docs/superpowers/specs/2026-06-09-codigo-abs-niveles-design.md
@@ -1,0 +1,161 @@
+# Código ABS — Suscripción mensual con niveles (modelo shell → planificaciones)
+
+**Fecha:** 2026-06-09
+**Autor:** Emilio + Claude
+**Estado:** Diseño para revisión (v2 — modelo shell→planes)
+
+---
+
+## 1. Contexto y objetivo
+
+Convertir el concepto del manuscrito "Código A.B.S" de Felipe Bejarano (libro finito: 100 días, 50 rutinas, 3 enfoques A/B/C, 5 fases) en el **nuevo producto flagship de Felipe en WAKE**: una suscripción mensual donde el macro se renueva y las rutinas cambian, para que la gente siga pagando sin aburrirse de los mismos ejercicios.
+
+> El manuscrito está **incompleto** (teoría + R1–21; faltan R22–50, el nivel Intermedio y el capítulo de nutrición). Completar el contenido es homework de Felipe, no código.
+
+### Decisiones de producto (cerradas)
+
+1. **ABS es flagship.** Reusa la maquinaria de suscripción (general, `monthly_first_monday`, cron del primer lunes, acceso rodante, política historial-se-queda/contenido-se-bloquea). El Método pasa a segundo plano.
+2. **Tres niveles:** Principiante / Intermedio / Avanzado.
+3. **Modelo shell → planificaciones (idea de Emilio):** el programa ABS es un **caparazón**; cada nivel **apunta a una planificación entera e independiente** (`plans/{planId}`), autorizada con las herramientas que ya existen para asesorías. Los niveles pueden ser **rutinas completamente distintas**, no solo "mismo patrón, otro ejercicio".
+4. **El nivel se elige por programa**, no en onboarding. Se pregunta al **primer ingreso a la Hoy/main screen, antes de la primera sesión** (no en el checkout, para no fricciónar el pago). Default mientras no elige = el default del programa.
+5. **Etiqueta de nivel visible y cambiable.** En el reverso del Hoy card: etiqueta (Principiante/Intermedio/Avanzado) + dropdown para cambiar de planificación cuando quiera.
+6. **Implementación entera y reutilizable** (no "v1 mínimo"): cualquier programa futuro podrá ser un shell multi-planificación.
+7. **Todo aditivo.** Programas sin niveles se comportan exactamente como hoy.
+8. **Subimos el primer año completo** (12 meses) de las 3 planificaciones de una vez.
+
+---
+
+## 2. Ground truth (verificado en código + BD de producción wolf-20b8b)
+
+### Árbol de PLANES = idéntico a cursos
+`plans/{planId}/modules/{moduleId}/sessions/{sessionId}/exercises/{exerciseId}/sets/{setId}`
+- **Plan root:** `title`, `description`, `creator_id`, `creatorName`, `discipline?`.
+- **Module:** `title` ("Semana 7"), `order`. (En asesorías un módulo = una semana.)
+- **Session:** `title`, `order`, `dayIndex`, `isRestDay?`, `source_library_session_id`, `image_url`, `defaultDataTemplate`.
+- **Exercise:** `primary: {libId: exId}`, `alternatives`, `measures`, `objectives`, custom labels (mismo shape que cursos; nombre/video se hidratan de la librería).
+- **Set:** `reps` (rangos/AMRAP), `intensity` ("N/10"), `rir?`, `restSeconds`, `duration?`, `rep_sequence?` (arco), `notes`.
+
+### Autoría de planes (dashboard) — ya existe y se reusa
+`/plans`, `/plans/new`, `/plans/{planId}` → `PlanDetailScreen` + `PlanStructureSidebar` + `PlanWeeksGrid` + `PlanSessionDetailScreen`, reusando **los mismos componentes de edición de sesión/ejercicio que los cursos** (`LibrarySessionDetailScreen`). Servicio `plansService.js`. CRUD completo en [creator.ts](../../../functions/src/api/routes/creator.ts) bajo `/creator/plans/...`.
+
+### Indirección shell→plan — ya existe (es lo que generalizamos)
+En [workout.ts](../../../functions/src/api/routes/workout.ts) el path **one_on_one** (~323–593) y el **plan-based** (~595–688) resuelven contenido así:
+`planAssignments[clave] → {planId, moduleId} → plans/{planId}/modules/{moduleId}/sessions/...`
+Hoy la clave es la semana ISO ("2026-W21"). **Nuestro cambio: la clave/selección será (nivel + mes vigente), no la asignación manual por semana.**
+
+### Cadencia mensual — ya existe
+- Read general (~690–900): filtra `courses/{id}/modules` por `order <= current_block_index`.
+- Cron `advanceMonthlyDropCourse` ([index.ts](../../../functions/src/index.ts) ~2704–2843, `every monday 01:00` BOG): busca el siguiente módulo con `published_at != null` y `order > current_block_index`; escribe `program_state/{courseId}` + `courses.current_block_id/index`. Idempotente por `current_block_started_at` (mes BOG). Cron de verificación día 2–8.
+- Access gate `courseAccessIsActive()` (~119–137): `expires_at` + gracia 3 días + `status==active`/`is_trial`. Cadenced → exige suscripción activa; no-cadenced → "published-means-public".
+
+### Selección de sesión (scheduling weekly)
+Las sesiones `weekly` (`dayIndex` 1..7) **se repiten cada semana del mes**; hoy NO hay noción de "semana-del-mes" que cambie ejercicios (solo `rep_sequence` varía reps por semana).
+
+### Offline / descarga
+El agente **no encontró `courseDownloadService`** (mi memoria lo mencionaba). Hoy parece ser solo el cache en memoria de `sessionService` (TTL 5 min). **A confirmar** antes de tocar offline; el único cambio necesario sería incluir el nivel en la clave de cache.
+
+---
+
+## 3. Arquitectura (3 pilares aditivos)
+
+### Pilar 1 — Niveles vía shell→planes
+- **Course (shell) nuevo campo `level_plans`:**
+  ```
+  level_plans: { principiante: planIdP, intermedio: planIdI, avanzado: planIdA }
+  ```
+- **Course nuevo campo `levels`:** `{ options:["principiante","intermedio","avanzado"], default:"principiante" }`.
+- **Enrollment nuevo campo `users.courses[courseId].level`:** el nivel elegido. Si falta → `course.levels.default`.
+- Cada nivel = un `plans/{planId}` independiente (12 módulos-mes). Sin `level_plans` → el curso no es escalable (comportamiento actual).
+
+### Pilar 2 — Cadencia mensual sobre los planes
+- `program_state/{courseId}.current_block_index` = el **mes vigente** (ordinal, cohort-sync). Lo avanza el cron del primer lunes, igual que hoy.
+- **Cambio en el cron:** cuando el curso tiene `level_plans`, en vez de mirar `courses/{id}/modules`, mira los módulos de los planes de nivel: avanza al `order = current+1` **solo si ese mes está publicado en las 3 planificaciones** (ningún nivel se queda sin contenido). Escribe `program_state` + `course.current_block_index` igual que hoy.
+
+### Pilar 3 — Variedad semanal dentro del mes (el "que cambien cada semana")
+Para que las rutinas cambien semana a semana con **ejercicios distintos** (no solo reps), añadimos un eje de semana:
+- **Session nuevo campo `weekIndex`** (0..4) además de `dayIndex`. Un mes-módulo trae hasta 4–5 semanas × 3 días de sesiones distintas.
+- **`weekInBlock` (cohort-sync, computado, sin cron nuevo):**
+  `weekInBlock = clamp(floor((hoy − program_state.current_block_started_at) / 7d), 0, maxWeekIndex)`.
+- **Selección:** las sesiones de hoy = del mes vigente, donde `weekIndex == weekInBlock` y `dayIndex == díaDeHoy`.
+- Aditivo: sesiones sin `weekIndex` → se repiten cada semana (comportamiento actual del Método intacto).
+
+### Resolución completa del read para ABS (general + level_plans)
+```
+userLevel   = users.courses[courseId].level ?? course.levels.default
+planId      = course.level_plans[userLevel]
+monthModule = plans[planId].modules where order == program_state.current_block_index
+weekInBlock = clamp(floor((today − current_block_started_at)/7d), 0, maxWeek)
+todaySessions = monthModule.sessions where weekIndex == weekInBlock AND dayIndex == hoy
+```
+Sin `level_plans` o sin `weekIndex` → comportamiento idéntico al de hoy. **Cero migración, no rompe nada.**
+
+### Por qué es la arquitectura correcta
+- Reusa el árbol de planes, el editor de planes y la indirección shell→plan que ya existen.
+- Niveles = planificaciones enteras (máxima libertad para Felipe).
+- Cadencia mensual cohort-sync intacta; variedad semanal vía `weekIndex` computado (sin cron nuevo).
+- Generaliza a cualquier programa futuro.
+
+---
+
+## 4. Mapeo del macro
+
+| Capa | Doc | Notas |
+|---|---|---|
+| Programa ABS (shell) | `courses/{id}` | `general`, `monthly_first_monday`, `subscription_price`, `levels`, `level_plans`, creator Felipe |
+| Planificación (×3, una por nivel) | `plans/{planId}` | 12 módulos-mes; autorizada con el editor de planes existente |
+| Mes (bloque) | `plans/.../modules/{id}` | `order` 0–11; `published_at` = gate del cron; tema en `title` |
+| Semana | `weekIndex` en sesiones | la rutina cambia por semana dentro del mes |
+| Día/Rutina | `plans/.../sessions/{id}` | enfoque A/B/C vía `dayIndex` (~3/sem) |
+| Serie | `plans/.../sets/{id}` | `reps`/`AMRAP`/`duration`, `intensity`, `restSeconds`, `rep_sequence` |
+
+---
+
+## 5. Cambios por superficie (revisión de TODO lo que toca)
+
+### A. Esquema (aditivo)
+- `course.level_plans`, `course.levels`, `users.courses[courseId].level`, `session.weekIndex`.
+- Planes: sin cambios de esquema (se reusan). Sin migración de datos.
+
+### B. API (functions)
+1. **Read workout** ([workout.ts](../../../functions/src/api/routes/workout.ts)): nueva rama "general + level_plans" que resuelve `nivel → plan → módulo(order==current_block_index) → sesiones(weekIndex==weekInBlock)`. Reusa el helper de lectura de planes (one_on_one). Aplica en `/workout/daily`, `/workout/session-exercises`, `/workout/programs/:courseId/modules`, `/current-block`.
+2. **Cron** `advanceMonthlyDropCourse` ([index.ts](../../../functions/src/index.ts)): rama que gatea la publicación sobre los `level_plans` (los 3 planes deben tener el siguiente mes publicado).
+3. **Nuevo endpoint** `PATCH /users/me/courses/:courseId/level` → set/cambia `users.courses[courseId].level` (valida contra `course.levels.options`).
+4. **Enrollment** ([courseAssignment.ts](../../../functions/src/api/services/courseAssignment.ts) + trial grant en [payments.ts](../../../functions/src/api/routes/payments.ts)): **NO** escribe `level` (lo deja ausente, para que el modal de primer ingreso pueda dispararse); el read cae a `course.levels.default` mientras esté ausente. Preservar el `level` elegido en renovación.
+5. **Creator** ([creator.ts](../../../functions/src/api/routes/creator.ts)): endpoint para setear `level_plans` en el shell (extender `PATCH /creator/programs/:programId` o un `assign-level-plan`). **No se tocan allowlists de ejercicios** (no hay variantes por ejercicio). Agregar `weekIndex` a la allowlist de sesiones de plan.
+
+### C. Plataforma de creadores (apps/creator-dashboard)
+- **Vista del programa (shell):** nueva config **"Planificaciones por nivel"** — mapear cada nivel a un plan existente (o crear uno). Reusa la lista de planes + el patrón assign-plan. Diseño según `feedback_creator_dashboard_design`.
+- **Editor de sesión de plan:** agregar el selector de `weekIndex` (junto a `dayIndex`) para autorizar semanas distintas dentro de un mes.
+- **Editor de planes:** sin cambios (Felipe crea 3 planes con lo que existe).
+
+### D. Compras / enrollment + dónde se pregunta el nivel
+- Flujo de compra intacto (`CourseDetailScreen` → `prepareSubscription` → `/payments/subscription` → MP → webhook escribe enrollment **sin** `level`).
+- **Modal de nivel** en la **Hoy/main screen al primer ingreso** (gate: `users.courses[courseId].level` ausente), antes de la primera sesión → `PATCH .../level`. Mientras esté ausente, el contenido se sirve con `course.levels.default`.
+
+### E. Experiencia de entrenamiento (PWA)
+- **Hoy card (reverso):** etiqueta del nivel + **dropdown** para cambiar de planificación → `PATCH .../level` → refetch.
+- El servidor resuelve el contenido por (nivel, mes, semana); el cliente solo renderiza.
+- `sessionService` cache key: incluir `level` (cambiar de nivel refetchea).
+- Offline: confirmar `courseDownloadService`; si existe, pasar `level` al fetch del bloque.
+
+### F. Onboarding
+- **Sin cambios.** El nivel es por-programa.
+
+### G. Carga del primer año (contenido)
+- Crear shell **"Código ABS"** (general, monthly_first_monday, `subscription_price`, `levels`, `level_plans`, capacity si beta).
+- Crear **3 planes** (principiante/intermedio/avanzado), cada uno con **12 módulos-mes**, sesiones con `weekIndex`+`dayIndex` (enfoques A/B/C), sets con `rep_sequence`+`intensity`.
+- Librería base de ~15–20 movimientos (reusada por los 3 planes).
+- Vía **seed script** (patrón `scripts/seed-metodo-bejarano.js`). Todo `draft`/`published_at` controlado hasta revisión de Felipe.
+
+---
+
+## 6. Decisiones (resueltas)
+
+1. **Variedad semanal (Pilar 3):** ✅ **Ejercicios distintos cada semana** vía `weekIndex` (~12 sesiones/mes por nivel = 4 semanas × 3 días). Es la implementación entera.
+2. **Avance del cron con 3 planes:** ✅ gatear a que **los 3 niveles** tengan el siguiente mes publicado (ningún nivel se queda sin contenido).
+3. **Cambiar de nivel a mitad de mes:** ✅ mantiene el mismo `weekInBlock` (cohort-sync); solo cambia de planificación, no reinicia la semana.
+
+## 7. Fuera de alcance
+- Capítulo de nutrición del manuscrito (producto aparte).
+- Completar contenido R22–50 / nivel Intermedio (homework de Felipe).
+- Personalización por usuario tipo asesoría (copy-on-write `client_plan_content`) — ABS es cohort, no 1-a-1.

--- a/functions/lib/landing-index.html
+++ b/functions/lib/landing-index.html
@@ -24,7 +24,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" rel="stylesheet" />
-    <script type="module" crossorigin src="/assets/index-WBnouSy-.js"></script>
+    <script type="module" crossorigin src="/assets/index-C2lx5T1-.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-D_9PU5bc.css">
   </head>
   <body>

--- a/functions/src/api/routes/creator.ts
+++ b/functions/src/api/routes/creator.ts
@@ -5352,7 +5352,7 @@ router.patch("/creator/plans/:planId/modules/:moduleId/sessions/:sessionId", asy
 
   if (updates.weekIndex !== undefined && updates.weekIndex !== null) {
     const v = updates.weekIndex;
-    if (!Number.isInteger(v) || (v as number) < 0) {
+    if (typeof v !== "number" || !Number.isInteger(v) || v < 0) {
       throw new WakeApiServerError(
         "VALIDATION_ERROR", 400,
         "weekIndex debe ser un entero mayor o igual a 0, o null",

--- a/functions/src/api/routes/creator.ts
+++ b/functions/src/api/routes/creator.ts
@@ -1607,8 +1607,45 @@ router.patch("/creator/programs/:programId", async (req, res) => {
     // Enforced at checkout via capacity.ts; counts buyers past the cap into a
     // waitlist instead.
     "capacity",
+    // Código ABS niveles: level key → planId mapping and level option metadata.
+    "level_plans",
+    "levels",
   ];
   const updates = pickFields(req.body, allowedFields);
+
+  if (updates.level_plans !== undefined && updates.level_plans !== null) {
+    const v = updates.level_plans;
+    if (
+      typeof v !== "object" ||
+      Array.isArray(v) ||
+      Object.values(v as Record<string, unknown>).some((val) => typeof val !== "string")
+    ) {
+      throw new WakeApiServerError(
+        "VALIDATION_ERROR", 400,
+        "level_plans debe ser un objeto con valores string (nivel → planId)",
+        "level_plans"
+      );
+    }
+  }
+
+  if (updates.levels !== undefined && updates.levels !== null) {
+    const v = updates.levels as { options?: unknown; default?: unknown };
+    if (
+      typeof v !== "object" ||
+      Array.isArray(v) ||
+      !Array.isArray(v.options) ||
+      (v.options as unknown[]).length === 0 ||
+      (v.options as unknown[]).some((o) => typeof o !== "string") ||
+      typeof v.default !== "string" ||
+      !(v.options as string[]).includes(v.default as string)
+    ) {
+      throw new WakeApiServerError(
+        "VALIDATION_ERROR", 400,
+        "levels debe tener options (array de strings no vacío) y default (string incluido en options)",
+        "levels"
+      );
+    }
+  }
 
   if (updates.capacity !== undefined && updates.capacity !== null) {
     const v = updates.capacity;
@@ -5092,6 +5129,7 @@ router.post("/creator/plans/:planId/modules/:moduleId/sessions", async (req, res
   const body = validateBody<{
     title: string; order: number; isRestDay?: boolean;
     source_library_session_id?: string; dayIndex?: number; image_url?: string;
+    weekIndex?: number | null;
   }>(
     {
       title: "string",
@@ -5100,9 +5138,21 @@ router.post("/creator/plans/:planId/modules/:moduleId/sessions", async (req, res
       source_library_session_id: "optional_string",
       dayIndex: "optional_number",
       image_url: "optional_string",
+      weekIndex: "optional_number",
     },
     req.body
   );
+
+  // weekIndex must be null or a non-negative integer when provided
+  if (body.weekIndex !== undefined && body.weekIndex !== null) {
+    if (!Number.isInteger(body.weekIndex) || body.weekIndex < 0) {
+      throw new WakeApiServerError(
+        "VALIDATION_ERROR", 400,
+        "weekIndex debe ser un entero mayor o igual a 0, o null",
+        "weekIndex"
+      );
+    }
+  }
 
   // Support legacy field name from old clients
   const sourceLibSessionId = body.source_library_session_id ?? (req.body.librarySessionRef as string | undefined) ?? null;
@@ -5114,6 +5164,7 @@ router.post("/creator/plans/:planId/modules/:moduleId/sessions", async (req, res
     ...(sourceLibSessionId && {source_library_session_id: sourceLibSessionId}),
     ...(body.dayIndex !== undefined && {dayIndex: body.dayIndex}),
     ...(body.image_url !== undefined && {image_url: body.image_url}),
+    ...(body.weekIndex !== undefined && {weekIndex: body.weekIndex}),
     created_at: FieldValue.serverTimestamp(),
     updated_at: FieldValue.serverTimestamp(),
   };
@@ -5292,11 +5343,22 @@ router.patch("/creator/plans/:planId/modules/:moduleId/sessions/:sessionId", asy
   const doc = await ref.get();
   if (!doc.exists) throw new WakeApiServerError("NOT_FOUND", 404, "Sesión no encontrada");
 
-  const allowedFields = ["title", "order", "isRestDay", "source_library_session_id", "dayIndex", "image_url", "defaultDataTemplate"];
+  const allowedFields = ["title", "order", "isRestDay", "source_library_session_id", "dayIndex", "image_url", "defaultDataTemplate", "weekIndex"];
   const updates = pickFields(req.body, allowedFields);
 
   if (Object.keys(updates).length === 0) {
     throw new WakeApiServerError("VALIDATION_ERROR", 400, "No se proporcionaron campos para actualizar");
+  }
+
+  if (updates.weekIndex !== undefined && updates.weekIndex !== null) {
+    const v = updates.weekIndex;
+    if (!Number.isInteger(v) || (v as number) < 0) {
+      throw new WakeApiServerError(
+        "VALIDATION_ERROR", 400,
+        "weekIndex debe ser un entero mayor o igual a 0, o null",
+        "weekIndex"
+      );
+    }
   }
 
   await ref.update({...updates, updated_at: FieldValue.serverTimestamp()});

--- a/functions/src/api/routes/payments.ts
+++ b/functions/src/api/routes/payments.ts
@@ -48,6 +48,42 @@ function pickRecipientEmail(
   return null;
 }
 
+// ── Checkout observability ────────────────────────────────────────────────
+// Full-fidelity logging so any subscription checkout can be reconstructed end
+// to end from Cloud Logging. Every step emits a structured entry under
+// `checkout.<step>` tagged with `flow:"checkout"` and a correlation id
+// (subscriptionId / external_reference). MercadoPago request + response
+// payloads are logged VERBATIM under `mp` — they carry no card data (neither
+// the redirect nor the transparent flow exposes a PAN to us) and no secrets
+// (access token / webhook secret never appear in MP payloads). The buyer email
+// IS present in MP payloads and in `payerEmail`/`accountEmail` fields: this is
+// intentional — the whole investigation is an account-vs-payer email mismatch,
+// so the addresses are the signal. Keep these logs access-controlled.
+function logCheckout(step: string, data: Record<string, unknown>): void {
+  functions.logger.info(`checkout.${step}`, {flow: "checkout", step, ...data});
+}
+
+// Pull a usable {status, message, raw} out of whatever MP threw. The SDK throws
+// plain objects ({message, status, cause}) as often as Error instances.
+function describeMpError(error: unknown): {
+  mpStatus: number | string | null;
+  mpMessage: string;
+  mpRaw: unknown;
+} {
+  if (error instanceof Error) {
+    return {mpStatus: null, mpMessage: error.message, mpRaw: {name: error.name, message: error.message}};
+  }
+  if (error && typeof error === "object") {
+    const o = error as {message?: unknown; status?: unknown; cause?: unknown; error?: unknown};
+    return {
+      mpStatus: (typeof o.status === "number" || typeof o.status === "string") ? o.status : null,
+      mpMessage: typeof o.message === "string" ? o.message : JSON.stringify(o),
+      mpRaw: o,
+    };
+  }
+  return {mpStatus: null, mpMessage: String(error), mpRaw: String(error)};
+}
+
 // MercadoPago redirects the buyer back to one of these URLs after checkout.
 // We derive the host from the caller's Origin header when it's in the trusted
 // allowlist (so staging redirects to staging, custom-domain redirects to the
@@ -288,10 +324,11 @@ router.post("/payments/subscription", async (req, res) => {
   const auth = await validateAuth(req);
   await checkRateLimit(auth.userId, 200, "rate_limit_first_party");
 
-  const body = validateBody<{ courseId: string; payer_email: string }>(
-    {courseId: "string", payer_email: "string"},
+  const body = validateBody<{ courseId: string; payer_email: string; surface?: string }>(
+    {courseId: "string", payer_email: "string", surface: "optional_string"},
     req.body
   );
+  const surface = typeof body.surface === "string" ? body.surface : "unknown";
 
   if (!COURSE_ID_RE.test(body.courseId)) {
     throw new WakeApiServerError("VALIDATION_ERROR", 400, "courseId inválido", "courseId");
@@ -352,6 +389,16 @@ router.post("/payments/subscription", async (req, res) => {
     throw new WakeApiServerError("NOT_FOUND", 404, "Usuario no encontrado");
   }
 
+  // Classify the email the client chose so we can later compare strand-rates of
+  // "account" vs "custom" choosers. Account email comes from the verified user
+  // doc; payer_email is whatever the proactive email step sent.
+  const accountEmail =
+    typeof userDoc.data()?.email === "string" ?
+      (userDoc.data()?.email as string).trim().toLowerCase() :
+      null;
+  const emailType: "account" | "custom" =
+    accountEmail && accountEmail === body.payer_email ? "account" : "custom";
+
   const client = getMPClient();
   const preapproval = new PreApproval(client);
   const startDate = new Date(Date.now() + 5 * 60 * 1000);
@@ -371,6 +418,19 @@ router.post("/payments/subscription", async (req, res) => {
   // Without this, MP falls back to the account-level URL configured in the
   // dashboard — silently dropping webhooks if that URL is wrong/missing.
   const notificationUrl = resolveWebhookUrl();
+
+  logCheckout("subscription.create.attempt", {
+    userId: auth.userId,
+    courseId: body.courseId,
+    externalReference: externalRef,
+    surface,
+    emailType,
+    payerEmail: body.payer_email,
+    accountEmail,
+    monthlyPrice,
+    trialDays,
+    deliveryType: course.deliveryType ?? null,
+  });
 
   let result;
   try {
@@ -402,22 +462,27 @@ router.post("/payments/subscription", async (req, res) => {
       },
     });
   } catch (error: unknown) {
-    // MP SDK throws plain objects ({message, status}), not Error instances —
-    // pull .message off the object directly so the alt-email patterns still match.
-    let rawMsg: string;
-    if (error instanceof Error) {
-      rawMsg = error.message;
-    } else if (error && typeof error === "object" && typeof (error as {message?: unknown}).message === "string") {
-      rawMsg = (error as {message: string}).message;
-    } else {
-      rawMsg = String(error);
-    }
-    const msg = rawMsg.toLowerCase();
+    // MP SDK throws plain objects ({message, status}), not Error instances.
+    const {mpStatus, mpMessage, mpRaw} = describeMpError(error);
+    const msg = mpMessage.toLowerCase();
     const needsAltEmail =
       msg.includes("cannot operate between different") ||
       msg.includes("payer_email") ||
       msg.includes("belongs to another user") ||
       msg.includes("must belong to this site");
+
+    logCheckout("subscription.create.fail", {
+      userId: auth.userId,
+      courseId: body.courseId,
+      externalReference: externalRef,
+      surface,
+      emailType,
+      payerEmail: body.payer_email,
+      needsAltEmail,
+      mpStatus,
+      mpMessage,
+      mp: mpRaw,
+    });
 
     if (needsAltEmail) {
       res.status(409).json({
@@ -428,6 +493,16 @@ router.post("/payments/subscription", async (req, res) => {
     }
     throw error;
   }
+
+  logCheckout("subscription.create.mp_response", {
+    userId: auth.userId,
+    courseId: body.courseId,
+    externalReference: externalRef,
+    subscriptionId: result.id ?? null,
+    surface,
+    emailType,
+    mp: result,
+  });
 
   if (!result.init_point || !result.id) {
     throw new WakeApiServerError("INTERNAL_ERROR", 500, "No se pudo crear el enlace de pago");
@@ -470,6 +545,18 @@ router.post("/payments/subscription", async (req, res) => {
       created_at: FieldValue.serverTimestamp(),
       updated_at: FieldValue.serverTimestamp(),
     }, {merge: true});
+
+  logCheckout("subscription.create.ok", {
+    userId: auth.userId,
+    courseId: body.courseId,
+    externalReference: externalRef,
+    subscriptionId: result.id,
+    surface,
+    emailType,
+    status: result.status ?? null,
+    trialDays,
+    nextBillingDate,
+  });
 
   res.json({data: {init_point: result.init_point, subscription_id: result.id, free_trial_days: trialDays}});
 });
@@ -547,10 +634,13 @@ router.post("/payments/bundle-subscription", async (req, res) => {
   const body = validateBody<{
     bundleId: string;
     payer_email: string;
+    surface?: string;
   }>({
     bundleId: "string",
     payer_email: "string",
+    surface: "optional_string",
   }, req.body);
+  const surface = typeof body.surface === "string" ? body.surface : "unknown";
 
   if (!COURSE_ID_RE.test(body.bundleId)) {
     throw new WakeApiServerError("VALIDATION_ERROR", 400, "bundleId inválido", "bundleId");
@@ -591,6 +681,25 @@ router.post("/payments/bundle-subscription", async (req, res) => {
   const frequencyType = "months";
   const frequency = 1;
 
+  const accountEmail =
+    typeof userDoc.data()?.email === "string" ?
+      (userDoc.data()?.email as string).trim().toLowerCase() :
+      null;
+  const emailType: "account" | "custom" =
+    accountEmail && accountEmail === body.payer_email ? "account" : "custom";
+
+  logCheckout("subscription.create.attempt", {
+    userId: auth.userId,
+    bundleId: body.bundleId,
+    externalReference: externalRef,
+    kind: "bundle",
+    surface,
+    emailType,
+    payerEmail: body.payer_email,
+    accountEmail,
+    monthlyPrice: price,
+  });
+
   let result;
   try {
     result = await preapproval.create({
@@ -615,22 +724,27 @@ router.post("/payments/bundle-subscription", async (req, res) => {
       },
     });
   } catch (error: unknown) {
-    // MP SDK throws plain objects ({message, status}), not Error instances —
-    // pull .message off the object directly so the alt-email patterns still match.
-    let rawMsg: string;
-    if (error instanceof Error) {
-      rawMsg = error.message;
-    } else if (error && typeof error === "object" && typeof (error as {message?: unknown}).message === "string") {
-      rawMsg = (error as {message: string}).message;
-    } else {
-      rawMsg = String(error);
-    }
-    const msg = rawMsg.toLowerCase();
+    const {mpStatus, mpMessage, mpRaw} = describeMpError(error);
+    const msg = mpMessage.toLowerCase();
     const needsAltEmail =
       msg.includes("cannot operate between different") ||
       msg.includes("payer_email") ||
       msg.includes("belongs to another user") ||
       msg.includes("must belong to this site");
+
+    logCheckout("subscription.create.fail", {
+      userId: auth.userId,
+      bundleId: body.bundleId,
+      externalReference: externalRef,
+      kind: "bundle",
+      surface,
+      emailType,
+      payerEmail: body.payer_email,
+      needsAltEmail,
+      mpStatus,
+      mpMessage,
+      mp: mpRaw,
+    });
 
     if (needsAltEmail) {
       res.status(409).json({
@@ -683,6 +797,19 @@ router.post("/payments/bundle-subscription", async (req, res) => {
       created_at: FieldValue.serverTimestamp(),
       updated_at: FieldValue.serverTimestamp(),
     }, {merge: true});
+
+  logCheckout("subscription.create.ok", {
+    userId: auth.userId,
+    bundleId: body.bundleId,
+    externalReference: externalRef,
+    subscriptionId: result.id,
+    kind: "bundle",
+    surface,
+    emailType,
+    status: result.status ?? null,
+    nextBillingDate,
+    mp: result,
+  });
 
   res.json({data: {init_point: result.init_point, subscription_id: result.id}});
 });
@@ -843,6 +970,18 @@ router.post("/payments/webhook", async (req: Request, res) => {
   const webhookType = req.body?.type;
   const webhookAction = req.body?.action;
 
+  // Full raw capture of every signature-valid webhook MercadoPago sends, so a
+  // checkout can be reconstructed from logs. Correlation id is the MP resource
+  // id in data.id (a preapproval or payment id depending on type).
+  logCheckout("webhook.received", {
+    webhookType,
+    webhookAction,
+    dataId: req.body?.data?.id ?? null,
+    liveMode: req.body?.live_mode ?? null,
+    query: req.query ?? null,
+    mp: req.body,
+  });
+
   // ── subscription_preapproval (status updates only) ──
   if (webhookType === "subscription_preapproval") {
     const preapprovalId = req.body?.data?.id;
@@ -855,6 +994,13 @@ router.post("/payments/webhook", async (req: Request, res) => {
       const preapproval = new PreApproval(client);
       const preapprovalData = await preapproval.get({id: preapprovalId}) as unknown as MercadoPagoPreapproval;
       const externalReference = preapprovalData?.external_reference;
+      logCheckout("webhook.preapproval.fetched", {
+        preapprovalId,
+        externalReference: externalReference ?? null,
+        mpStatus: preapprovalData?.status ?? null,
+        payerEmail: preapprovalData?.payer_email ?? null,
+        mp: preapprovalData,
+      });
       if (!externalReference) {
         res.status(200).send("OK");
         return;
@@ -943,6 +1089,17 @@ router.post("/payments/webhook", async (req: Request, res) => {
         res.status(200).send("OK");
         return;
       }
+
+      logCheckout("webhook.preapproval.status", {
+        subscriptionId: preapprovalId,
+        userId: parsed.userId,
+        courseId: parsed.courseId ?? null,
+        bundleId: parsed.bundleId ?? null,
+        from: existingSubData.status ?? null,
+        to: preapprovalData?.status ?? null,
+        payerEmail: preapprovalData?.payer_email ?? null,
+        trialDays: Number(existingSubData.free_trial_days) || 0,
+      });
 
       await subRef.set(updateData, {merge: true});
 
@@ -1139,6 +1296,7 @@ router.post("/payments/webhook", async (req: Request, res) => {
   // Fetch payment from MercadoPago
   interface MercadoPagoPaymentData {
     status?: string;
+    status_detail?: string;
     external_reference?: string;
     subscription_id?: string;
     preapproval_id?: string;
@@ -1146,6 +1304,7 @@ router.post("/payments/webhook", async (req: Request, res) => {
     date_created?: string;
     transaction_amount?: number;
     currency_id?: string;
+    payer?: { email?: string };
     preapproval?: { id?: string; external_reference?: string };
     payment?: { status?: string };
   }
@@ -1173,6 +1332,14 @@ router.post("/payments/webhook", async (req: Request, res) => {
       const client = getMPClient();
       const payment = new Payment(client);
       paymentData = (await payment.get({id: paymentId}) as MercadoPagoPaymentData) || {};
+      logCheckout("webhook.payment.fetched", {
+        paymentId,
+        externalReference: paymentData?.external_reference ?? null,
+        mpStatus: paymentData?.status ?? null,
+        statusDetail: paymentData?.status_detail ?? null,
+        payerEmail: paymentData?.payer?.email ?? null,
+        mp: paymentData,
+      });
     }
   } catch (apiError: unknown) {
     const errType = classifyError(apiError);

--- a/functions/src/api/routes/public.ts
+++ b/functions/src/api/routes/public.ts
@@ -412,6 +412,13 @@ function truncateMpTitle(raw: string | undefined, fallback: string): string {
   return value.length > 200 ? value.slice(0, 197) + "…" : value;
 }
 
+// Mirror of payments.ts logCheckout: full-fidelity checkout-step logging under
+// `checkout.<step>` so storefront subscriptions can also be reconstructed from
+// Cloud Logging. MP payloads are logged verbatim (no card data, no secrets).
+function logCheckout(step: string, data: Record<string, unknown>): void {
+  functions.logger.info(`checkout.${step}`, {flow: "checkout", step, ...data});
+}
+
 router.post("/public/checkout/start", async (req, res) => {
   const auth = await validateAuth(req);
   await checkRateLimit(auth.userId, 30, "rate_limit_first_party");
@@ -421,6 +428,7 @@ router.post("/public/checkout/start", async (req, res) => {
     courseId: string;
     mode: "one_time" | "subscription";
     payerEmail?: string;
+    surface?: string;
   }>(
     {
       username: "string",
@@ -429,9 +437,11 @@ router.post("/public/checkout/start", async (req, res) => {
       // CR-5: must be declared in the schema or validateBody strips it,
       // breaking the alternate-email retry flow.
       payerEmail: "optional_string",
+      surface: "optional_string",
     },
     req.body
   );
+  const surface = typeof body.surface === "string" ? body.surface : "storefront";
 
   const username = (body.username || "").toLowerCase().trim();
   if (!USERNAME_RE.test(username)) {
@@ -679,9 +689,22 @@ router.post("/public/checkout/start", async (req, res) => {
   }
 
   const externalRef = buildExternalReference(auth.userId, body.courseId, "sub");
+  const emailType: "account" | "custom" =
+    payerEmailRaw === buyerEmail ? "account" : "custom";
   const client = getMpClient();
   const preapproval = new PreApproval(client);
   const startDate = new Date(Date.now() + 5 * 60 * 1000);
+
+  logCheckout("subscription.create.attempt", {
+    userId: auth.userId,
+    courseId: body.courseId,
+    externalReference: externalRef,
+    surface,
+    emailType,
+    payerEmail: payerEmailRaw,
+    accountEmail: buyerEmail,
+    monthlyPrice,
+  });
 
   let result;
   try {
@@ -702,12 +725,25 @@ router.post("/public/checkout/start", async (req, res) => {
       },
     });
   } catch (error: unknown) {
-    const msg = (error instanceof Error ? error.message : String(error)).toLowerCase();
+    const rawMsg = error instanceof Error ? error.message : String(error);
+    const msg = rawMsg.toLowerCase();
     const needsAltEmail =
       msg.includes("cannot operate between different") ||
       msg.includes("payer_email") ||
       msg.includes("belongs to another user") ||
       msg.includes("must belong to this site");
+
+    logCheckout("subscription.create.fail", {
+      userId: auth.userId,
+      courseId: body.courseId,
+      externalReference: externalRef,
+      surface,
+      emailType,
+      payerEmail: payerEmailRaw,
+      needsAltEmail,
+      mpMessage: rawMsg,
+      mp: error instanceof Error ? {name: error.name, message: error.message} : error,
+    });
 
     if (needsAltEmail) {
       res.status(409).json({
@@ -778,6 +814,18 @@ router.post("/public/checkout/start", async (req, res) => {
       created_at: FieldValue.serverTimestamp(),
       updated_at: FieldValue.serverTimestamp(),
     }, {merge: true});
+
+  logCheckout("subscription.create.ok", {
+    userId: auth.userId,
+    courseId: body.courseId,
+    externalReference: externalRef,
+    subscriptionId: result.id,
+    surface,
+    emailType,
+    status: result.status ?? null,
+    nextBillingDate,
+    mp: result,
+  });
 
   res.json({
     data: {

--- a/functions/src/api/routes/workout.ts
+++ b/functions/src/api/routes/workout.ts
@@ -159,6 +159,78 @@ function calculate1RM(weight: number, reps: number, intensity: number | null): n
   return numerator / denominator;
 }
 
+// History key shape: ${libraryId}_${libraryExerciseId} — keys to the *library's*
+// stable exercise id (the value of primary[libId] post-migration), NOT the session-
+// exercise doc id. Returns null when neither an explicit key nor primary[libId] is
+// available; callers skip the history write rather than persist a wrong-shape key.
+function deriveExerciseKey(ex: Record<string, unknown>): string | null {
+  if (typeof ex.exerciseKey === "string" && ex.exerciseKey) return ex.exerciseKey;
+  const primary = ex.primary as Record<string, string> | undefined;
+  const libId = (ex.libraryId as string | undefined) ?? (primary ? Object.keys(primary)[0] : null);
+  const libraryExId = libId && primary ? primary[libId] : null;
+  if (libId && libraryExId) return `${libId}_${libraryExId}`;
+  return null;
+}
+
+// Best estimated 1RM across a set list, plus the set that produced it.
+function computeBest1RM(
+  sets: Array<Record<string, unknown>>
+): { estimate: number; bestSet: { weight: number; reps: number; intensity: string | null } | null } {
+  let estimate = 0;
+  let bestSet: { weight: number; reps: number; intensity: string | null } | null = null;
+  for (const set of sets) {
+    const weight = Number(set.weight) || 0;
+    const reps = Number(set.reps) || 0;
+    if (weight <= 0 || reps <= 0) continue;
+    const intensity =
+      parseReportedIntensity(set.intensity as string) ??
+      parsePlannedIntensity(set.plannedIntensity as string) ??
+      null;
+    const est = calculate1RM(weight, reps, intensity);
+    if (est > estimate) {
+      estimate = est;
+      bestSet = {weight, reps, intensity: (set.intensity as string) ?? null};
+    }
+  }
+  return {estimate, bestSet};
+}
+
+// Heaviest set in a list (matches the prod lastPerformance.bestSet rule).
+function bestSetByWeight(
+  sets: Array<Record<string, unknown>>
+): Record<string, unknown> | null {
+  if (!sets.length) return null;
+  return sets.reduce((best, s) =>
+    (parseFloat(String(s.weight ?? 0)) > parseFloat(String(best.weight ?? 0)) ? s : best), sets[0]);
+}
+
+// Best estimated 1RM across a history `sessions` array, excluding one session —
+// used on reopen so a re-finish's PR check compares against the user's OTHER
+// sessions for that exercise, not against the session being replaced.
+function bestEstimateFromSessions(
+  sessions: Array<{ sessionId?: string; sets?: Array<Record<string, unknown>> }>,
+  excludeSessionId: string
+): number {
+  let best = 0;
+  for (const s of sessions) {
+    if (s.sessionId === excludeSessionId) continue;
+    const {estimate} = computeBest1RM(s.sets ?? []);
+    if (estimate > best) best = estimate;
+  }
+  return best;
+}
+
+// Most-recent session in a history array (latest date; ties resolved by array
+// order, since arrayUnion appends — later index is the more recent completion).
+function mostRecentSession<T extends { date?: string }>(sessions: T[]): T | null {
+  if (!sessions.length) return null;
+  let best = sessions[0];
+  for (const s of sessions) {
+    if ((s.date ?? "") >= (best.date ?? "")) best = s;
+  }
+  return best;
+}
+
 // ─── Week helpers (must match creator.ts and client-side getMondayWeek) ──────
 function getMondayWeek(date: Date = new Date()): string {
   const d = new Date(date);
@@ -1117,6 +1189,10 @@ router.get("/workout/daily", async (req, res) => {
       hasSession: true,
       isRestDay: false,
       emptyReason: null,
+      // True when the session being returned has already been completed (lifetime,
+      // for this course). Lets the Hoy card offer "Continuar sesión" (reopen) vs
+      // "Empezar de nuevo" instead of a plain start.
+      todaySessionAlreadyCompleted: completedSessionIds.has(targetSessionId),
       session: {
         sessionId: targetSessionId,
         moduleId: targetModuleId,
@@ -1450,6 +1526,7 @@ router.post("/workout/complete", async (req, res) => {
     plannedSnapshot?: unknown;
     courseName?: string;
     sessionName?: string;
+    replacesCompletionId?: string;
   }>(
     {
       courseId: "string",
@@ -1461,6 +1538,7 @@ router.post("/workout/complete", async (req, res) => {
       plannedSnapshot: "optional_object",
       courseName: "optional_string",
       sessionName: "optional_string",
+      replacesCompletionId: "optional_string",
     },
     raw,
     {maxArrayLength: 50}
@@ -1492,24 +1570,76 @@ router.post("/workout/complete", async (req, res) => {
     }
   }
 
-  // Pre-fetch existing PRs for all exercises to compare.
-  // History key shape: ${libraryId}_${libraryExerciseId} — keys to the *library's*
-  // stable exercise id (the value of primary[libId] post-migration), NOT the session-
-  // exercise doc id. This survives renames since the id is stable.
+  // Pre-fetch existing PRs for all exercises to compare. See deriveExerciseKey
+  // for the key shape; it returns null (skip) rather than persist a wrong-shape
+  // key, which would corrupt post-migration history.
   const exerciseKeys = exercises
-    .map((ex) => {
-      if (ex.exerciseKey) return ex.exerciseKey;
-      const primary = (ex as Record<string, unknown>).primary as Record<string, string> | undefined;
-      const libId = ex.libraryId ?? (primary ? Object.keys(primary)[0] : null);
-      const libraryExId = libId && primary ? primary[libId] : null;
-      if (libId && libraryExId) return `${libId}_${libraryExId}`;
-      // Do NOT fall back to ${libId}_${ex.exerciseName} — that was the pre-migration shape.
-      // Writing it post-migration corrupts history because rekeyed docs use ${libId}_${exerciseId}.
-      // Any caller missing both exerciseKey and primary[libId] indicates a bug; skip the
-      // history write rather than persist a wrong-shape key.
-      return null;
-    })
+    .map((ex) => deriveExerciseKey(ex as Record<string, unknown>))
     .filter(Boolean) as string[];
+
+  // ── Reopen handling ──────────────────────────────────────────────────────
+  // When replacesCompletionId is set, the client is re-finishing a session that
+  // was already completed (un-finished from the Hoy card). We must REPLACE that
+  // session's footprint, not append a duplicate: reuse its id + original date,
+  // and read the old session plus every affected history/lastPerformance doc so
+  // we can swap this session's contribution and recompute the derived aggregates.
+  const replaceId = body.replacesCompletionId;
+  let effectiveCompletionId = completionId;
+  let effectiveCompletionDate = completionDate;
+  let oldCompletedAt: string | null = null;
+  let isReopen = false;
+  let oldKeys: string[] = [];
+  const oldMuscleVolumes: Record<string, number> = {};
+  const exerciseHistoryMap: Record<string, {
+    sessions: Array<{ date?: string; sessionId?: string; sets?: Array<Record<string, unknown>> }>;
+    exerciseName?: string;
+  }> = {};
+  const reopenLastPerfMap: Record<string, Record<string, unknown>> = {};
+
+  if (replaceId) {
+    const oldDoc = await db
+      .collection("users")
+      .doc(auth.userId)
+      .collection("sessionHistory")
+      .doc(replaceId)
+      .get();
+    if (!oldDoc.exists) {
+      throw new WakeApiServerError("NOT_FOUND", 404, "Sesión no encontrada");
+    }
+    const oldData = oldDoc.data()!;
+    isReopen = true;
+    effectiveCompletionId = replaceId;
+    // Keep the session anchored to its original day — the week bucket and streak
+    // day must not move just because it was re-finished later.
+    effectiveCompletionDate = (oldData.date as string) ?? completionDate;
+    oldCompletedAt = (oldData.completedAt as string) ?? null;
+
+    const oldExercises = (oldData.exercises as Array<Record<string, unknown>>) ?? [];
+    oldKeys = oldExercises
+      .map((ex) => deriveExerciseKey(ex))
+      .filter(Boolean) as string[];
+    for (const ex of oldExercises) {
+      const muscles = (ex.primaryMuscles as string[]) ?? [];
+      const setCount = ((ex.sets as unknown[]) ?? []).length;
+      for (const m of muscles) oldMuscleVolumes[m] = (oldMuscleVolumes[m] ?? 0) + setCount;
+    }
+
+    const unionKeys = Array.from(new Set([...exerciseKeys, ...oldKeys]));
+    const [histDocs, lpDocs] = await Promise.all([
+      Promise.all(unionKeys.map((k) =>
+        db.collection("users").doc(auth.userId).collection("exerciseHistory").doc(k).get())),
+      Promise.all(unionKeys.map((k) =>
+        db.collection("users").doc(auth.userId).collection("exerciseLastPerformance").doc(k).get())),
+    ]);
+    histDocs.forEach((d, i) => {
+      exerciseHistoryMap[unionKeys[i]] = d.exists ?
+        (d.data() as typeof exerciseHistoryMap[string]) :
+        {sessions: []};
+    });
+    lpDocs.forEach((d, i) => {
+      if (d.exists) reopenLastPerfMap[unionKeys[i]] = d.data()!;
+    });
+  }
 
   // Fetch library docs to hydrate displayName for sessionHistory.exercises (W-7) and
   // lastPerformance.exerciseName (W-4). Without this, both surfaces persist whatever the
@@ -1598,9 +1728,12 @@ router.post("/workout/complete", async (req, res) => {
   const userDoc = await db.collection("users").doc(auth.userId).get();
   const userData = userDoc.data() ?? {};
 
-  // Update streak via shared function (full read already done, pass lastKnown to avoid re-read)
+  // Update streak via shared function (full read already done, pass lastKnown to avoid re-read).
+  // Reopen re-finishes an existing day, which is already counted — skip so we don't double-count.
   const storedLastActivity = userData.activityStreak?.lastActivityDate ?? userData.lastSessionDate ?? null;
-  const streakResult = await updateStreak(auth.userId, completionDate, storedLastActivity);
+  const streakResult = isReopen ?
+    {updated: false} :
+    await updateStreak(auth.userId, completionDate, storedLastActivity);
 
   // Compute 1RM per exercise and detect PRs
   const personalRecords: Array<{
@@ -1612,20 +1745,22 @@ router.post("/workout/complete", async (req, res) => {
 
   const batch = db.batch();
 
-  // 1. Session history
+  // 1. Session history. On reopen this overwrites the original doc in place
+  // (same id), preserving its original date + completedAt so it stays ordered
+  // where it was; only the performed exercises, duration and notes change.
   const sessionHistoryRef = db
     .collection("users")
     .doc(auth.userId)
     .collection("sessionHistory")
-    .doc(completionId);
+    .doc(effectiveCompletionId);
 
   batch.set(sessionHistoryRef, {
     courseId: body.courseId,
     sessionId: body.sessionId,
     exercises: hydratedExercises,
     durationMs: body.durationMs,
-    date: completionDate,
-    completedAt: body.completedAt,
+    date: effectiveCompletionDate,
+    completedAt: isReopen && oldCompletedAt ? oldCompletedAt : body.completedAt,
     userNotes: body.userNotes ?? null,
     plannedSnapshot: body.plannedSnapshot ?? null,
     ...(body.courseName ? {courseName: body.courseName} : {}),
@@ -1633,39 +1768,38 @@ router.post("/workout/complete", async (req, res) => {
     completed_at: FieldValue.serverTimestamp(),
   });
 
-  // 2. Exercise history + last performance + 1RM per exercise
+  // 2. Exercise history + last performance + 1RM per exercise.
+  // `notes` is the coach's prescriptive instruction for the upcoming set — not a
+  // record of what the user did. Strip it before persisting so history docs don't
+  // bloat with up-to-500-char strings the user never authored.
+  const stripNotes = (s: Record<string, unknown>): Record<string, unknown> => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const {notes: _n, ...rest} = s;
+    return rest;
+  };
+  const newKeySet = new Set<string>();
+
   for (let i = 0; i < hydratedExercises.length; i++) {
     const exercise = hydratedExercises[i];
     const exerciseKey = exerciseKeys[i];
     if (!exerciseKey) continue;
+    newKeySet.add(exerciseKey);
 
-    let bestEstimate1RM = 0;
-    let bestSet: { weight: number; reps: number; intensity: string | null } | null = null;
+    const historySets = (exercise.sets ?? []).map(stripNotes);
+    const {estimate: bestEstimate1RM, bestSet} = computeBest1RM(historySets);
 
-    for (const set of exercise.sets ?? []) {
-      const weight = set.weight ?? 0;
-      const reps = set.reps ?? 0;
-      if (weight <= 0 || reps <= 0) continue;
+    // PR detection. Normal path compares against the stored lastPerformance
+    // estimate; reopen compares against the best of the user's OTHER sessions for
+    // this exercise (excluding the one being replaced) so the check isn't circular.
+    const comparisonEstimate = isReopen ?
+      bestEstimateFromSessions(exerciseHistoryMap[exerciseKey]?.sessions ?? [], effectiveCompletionId) :
+      (existingPrMap[exerciseKey]?.estimate1RM ?? 0);
+    const hadPrior = isReopen ? comparisonEstimate > 0 : !!existingPrMap[exerciseKey];
 
-      const intensity =
-        parseReportedIntensity(set.intensity) ??
-        parsePlannedIntensity(set.plannedIntensity) ??
-        null;
-      const estimate = calculate1RM(weight, reps, intensity);
-
-      if (estimate > bestEstimate1RM) {
-        bestEstimate1RM = estimate;
-        bestSet = {weight, reps, intensity: set.intensity ?? null};
-      }
-    }
-
-    const existingPr = existingPrMap[exerciseKey];
-    const existingEstimate = existingPr?.estimate1RM ?? 0;
-
-    // Only count as PR if there's a previous record to beat (not first-time exercises)
-    if (existingPr && bestEstimate1RM > existingEstimate && bestSet) {
-      // exercise.exerciseName is hydrated above. Don't fall through to exerciseKey
-      // (which is `${libId}_${exerciseId}`) — that surfaces a 20-char id in the PR card.
+    // Only count as PR if there's a previous record to beat (not first-time exercises).
+    // exercise.exerciseName is hydrated above; don't fall through to exerciseKey
+    // (which is `${libId}_${exerciseId}`) — that surfaces a 20-char id in the PR card.
+    if (hadPrior && bestEstimate1RM > comparisonEstimate && bestSet) {
       personalRecords.push({
         exerciseKey,
         exerciseName: exercise.exerciseName ?? "Ejercicio",
@@ -1679,64 +1813,104 @@ router.post("/workout/complete", async (req, res) => {
       .doc(auth.userId)
       .collection("exerciseHistory")
       .doc(exerciseKey);
-
-    // `notes` is the coach's prescriptive instruction for the upcoming set —
-    // not a record of what the user did. Strip it before persisting into
-    // exerciseHistory/lastPerformance so historical records don't bloat with
-    // up-to-500-char strings the user never authored.
-    const stripNotes = (s: Record<string, unknown>): Record<string, unknown> => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const {notes: _n, ...rest} = s;
-      return rest;
-    };
-    const historySets = (exercise.sets ?? []).map(stripNotes);
-
-    batch.set(
-      historyRef,
-      {
-        // Store the display name on the history doc so downstream readers
-        // (analytics, PR cards) don't need to cross-reference lastPerformance.
-        exerciseName: exercise.exerciseName ?? null,
-        sessions: FieldValue.arrayUnion({
-          date: completionDate,
-          sessionId: completionId,
-          sets: historySets,
-        }),
-        updated_at: FieldValue.serverTimestamp(),
-      },
-      {merge: true}
-    );
-
     const lastPerfRef = db
       .collection("users")
       .doc(auth.userId)
       .collection("exerciseLastPerformance")
       .doc(exerciseKey);
+    const newEntry = {date: effectiveCompletionDate, sessionId: effectiveCompletionId, sets: historySets};
 
-    // Production format: exerciseId, exerciseName, libraryId, lastSessionId, lastPerformedAt, totalSets, bestSet
-    const exerciseSets = historySets;
-    const prodBestSet = exerciseSets.length > 0 ?
-      exerciseSets.reduce((best: Record<string, unknown>, s: Record<string, unknown>) => {
-        const bw = parseFloat(String(best.weight ?? 0));
-        const sw = parseFloat(String(s.weight ?? 0));
-        return sw > bw ? s : best;
-      }, exerciseSets[0]) :
-      null;
+    if (isReopen) {
+      // Swap this session's entry in the shared history list (filter the old one
+      // out by id, append the new), then recompute lastPerformance from whatever
+      // is now the most-recent session — which correctly leaves a newer session's
+      // lastPerformance untouched if this isn't the latest.
+      const prior = exerciseHistoryMap[exerciseKey]?.sessions ?? [];
+      const rebuilt = [...prior.filter((s) => s.sessionId !== effectiveCompletionId), newEntry];
+      batch.set(historyRef, {
+        exerciseName: exercise.exerciseName ?? null,
+        sessions: rebuilt,
+        updated_at: FieldValue.serverTimestamp(),
+      }, {merge: true});
 
-    batch.set(lastPerfRef, {
-      exerciseId: exercise.exerciseId ?? null,
-      // exercise.exerciseName was hydrated from library above. Avoid fallback to
-      // exercise.exerciseKey or exerciseKey — those are `${libId}_${exerciseId}` and
-      // would persist a 20-char id where the UI expects a display name.
-      exerciseName: exercise.exerciseName ?? null,
-      libraryId: exercise.libraryId ?? null,
-      lastSessionId: completionId,
-      lastPerformedAt: completionDate,
-      totalSets: exerciseSets.length,
-      bestSet: prodBestSet,
-      estimate1RM: bestEstimate1RM > 0 ? Math.round(bestEstimate1RM * 100) / 100 : existingEstimate,
-      updated_at: FieldValue.serverTimestamp(),
-    });
+      const recent = mostRecentSession(rebuilt);
+      const recentSets = recent?.sets ?? [];
+      const {estimate} = computeBest1RM(recentSets);
+      batch.set(lastPerfRef, {
+        exerciseId: exercise.exerciseId ?? null,
+        exerciseName: exercise.exerciseName ?? null,
+        libraryId: exercise.libraryId ?? null,
+        lastSessionId: recent?.sessionId ?? effectiveCompletionId,
+        lastPerformedAt: recent?.date ?? effectiveCompletionDate,
+        totalSets: recentSets.length,
+        bestSet: bestSetByWeight(recentSets),
+        estimate1RM: estimate > 0 ? Math.round(estimate * 100) / 100 : 0,
+        updated_at: FieldValue.serverTimestamp(),
+      });
+    } else {
+      // Store the display name on the history doc so downstream readers
+      // (analytics, PR cards) don't need to cross-reference lastPerformance.
+      batch.set(historyRef, {
+        exerciseName: exercise.exerciseName ?? null,
+        sessions: FieldValue.arrayUnion(newEntry),
+        updated_at: FieldValue.serverTimestamp(),
+      }, {merge: true});
+
+      const existingEstimate = existingPrMap[exerciseKey]?.estimate1RM ?? 0;
+      batch.set(lastPerfRef, {
+        exerciseId: exercise.exerciseId ?? null,
+        exerciseName: exercise.exerciseName ?? null,
+        libraryId: exercise.libraryId ?? null,
+        lastSessionId: effectiveCompletionId,
+        lastPerformedAt: effectiveCompletionDate,
+        totalSets: historySets.length,
+        bestSet: bestSetByWeight(historySets),
+        estimate1RM: bestEstimate1RM > 0 ? Math.round(bestEstimate1RM * 100) / 100 : existingEstimate,
+        updated_at: FieldValue.serverTimestamp(),
+      });
+    }
+  }
+
+  // 2b. Reopen only: exercises that were in the OLD session but removed in this
+  // re-finish. Pull this session out of their history and re-point (or clear)
+  // lastPerformance so nothing references a contribution that no longer exists.
+  if (isReopen) {
+    const removedKeys = oldKeys.filter((k) => !newKeySet.has(k));
+    for (const exerciseKey of removedKeys) {
+      const prior = exerciseHistoryMap[exerciseKey]?.sessions ?? [];
+      const rebuilt = prior.filter((s) => s.sessionId !== effectiveCompletionId);
+      const historyRef = db
+        .collection("users")
+        .doc(auth.userId)
+        .collection("exerciseHistory")
+        .doc(exerciseKey);
+      const lastPerfRef = db
+        .collection("users")
+        .doc(auth.userId)
+        .collection("exerciseLastPerformance")
+        .doc(exerciseKey);
+      batch.set(historyRef, {sessions: rebuilt, updated_at: FieldValue.serverTimestamp()}, {merge: true});
+
+      const recent = mostRecentSession(rebuilt);
+      if (recent) {
+        const recentSets = recent.sets ?? [];
+        const {estimate} = computeBest1RM(recentSets);
+        const existing = reopenLastPerfMap[exerciseKey] ?? {};
+        batch.set(lastPerfRef, {
+          exerciseId: existing.exerciseId ?? null,
+          exerciseName: existing.exerciseName ?? null,
+          libraryId: existing.libraryId ?? null,
+          lastSessionId: recent.sessionId ?? null,
+          lastPerformedAt: recent.date ?? null,
+          totalSets: recentSets.length,
+          bestSet: bestSetByWeight(recentSets),
+          estimate1RM: estimate > 0 ? Math.round(estimate * 100) / 100 : 0,
+          updated_at: FieldValue.serverTimestamp(),
+        });
+      } else {
+        batch.delete(lastPerfRef);
+      }
+    }
   }
 
   // 3. Compute muscle volumes from exercises
@@ -1749,36 +1923,30 @@ router.post("/workout/complete", async (req, res) => {
     }
   }
 
-  // 3b. Compute week key for weeklyMuscleVolume persistence
-  // Must match client-side getMondayWeek() in apps/pwa/src/utils/weekCalculation.js
-  const completionDateObj = new Date(completionDate);
-  completionDateObj.setHours(0, 0, 0, 0);
-  const dayOfWeek = completionDateObj.getDay();
-  const mondayOffset = completionDateObj.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1);
-  const monday = new Date(completionDateObj);
-  monday.setDate(mondayOffset);
-  const year = monday.getFullYear();
-  const jan1 = new Date(year, 0, 1);
-  const jan1Day = jan1.getDay();
-  const daysToFirstMonday = jan1Day === 0 ? 1 : 8 - jan1Day;
-  const firstMonday = new Date(jan1.getTime());
-  firstMonday.setDate(jan1.getDate() + daysToFirstMonday);
-  const daysDiff = Math.floor((monday.getTime() - firstMonday.getTime()) / (24 * 60 * 60 * 1000));
-  const weekNumber = Math.floor(daysDiff / 7) + 1;
-  const weekKey = `${year}-W${String(weekNumber).padStart(2, "0")}`;
+  // 3b. Week key for weeklyMuscleVolume persistence — anchored to the session's
+  // effective date (its original day on reopen). getMondayWeek matches the
+  // client-side getMondayWeek() in apps/pwa/src/utils/weekCalculation.js.
+  const weekKey = getMondayWeek(new Date(effectiveCompletionDate));
 
-  // Merge session volumes into existing weekly volumes (additive)
+  // Apply the session's volume to the week bucket. On reopen this is a delta —
+  // the old contribution is subtracted and the new one added (same bucket, since
+  // the date is preserved) — so a re-finish never double-counts. Normal path has
+  // no old volume, so delta === the new volume (plain additive, unchanged).
   const weeklyVolumeUpdate: Record<string, unknown> = {};
-  const existingWeeklyVolume = userData.weeklyMuscleVolume?.[weekKey] ?? {};
-  for (const [muscle, sets] of Object.entries(muscleVolumes)) {
-    const existing = (existingWeeklyVolume as Record<string, number>)[muscle] ?? 0;
-    weeklyVolumeUpdate[`weeklyMuscleVolume.${weekKey}.${muscle}`] = existing + sets;
+  const existingWeeklyVolume = (userData.weeklyMuscleVolume?.[weekKey] ?? {}) as Record<string, number>;
+  const volumeMuscles = new Set([...Object.keys(muscleVolumes), ...Object.keys(oldMuscleVolumes)]);
+  for (const muscle of volumeMuscles) {
+    const delta = (muscleVolumes[muscle] ?? 0) - (isReopen ? (oldMuscleVolumes[muscle] ?? 0) : 0);
+    if (delta === 0) continue;
+    const next = (existingWeeklyVolume[muscle] ?? 0) + delta;
+    weeklyVolumeUpdate[`weeklyMuscleVolume.${weekKey}.${muscle}`] = next < 0 ? 0 : next;
   }
 
-  // 4. Update user last session + weekly volume (streak already updated by updateStreak above)
+  // 4. Update user weekly volume (+ lastSessionDate, except on reopen — re-finishing
+  // an older session must not move the user's last-activity day backward).
   const userRef = db.collection("users").doc(auth.userId);
   batch.update(userRef, {
-    lastSessionDate: completionDate,
+    ...(isReopen ? {} : {lastSessionDate: completionDate}),
     ...weeklyVolumeUpdate,
     updated_at: FieldValue.serverTimestamp(),
   });
@@ -1797,7 +1965,7 @@ router.post("/workout/complete", async (req, res) => {
 
   res.json({
     data: {
-      completionId,
+      completionId: effectiveCompletionId,
       personalRecords,
       streakUpdated: streakResult.updated,
       muscleVolumes,


### PR DESCRIPTION
## Resumen
Primera tanda de **Código ABS** (suscripción mensual de abdomen con niveles vía modelo *shell→planificaciones*): el programa es un caparazón y cada nivel apunta a una planificación entera, reusando la infra de planes existente.

Incluye:
- **Diseño:** spec + 4 planes de implementación (`docs/superpowers/`).
- **API (functions):** allowlists aceptan `levels`/`level_plans` en `PATCH /creator/programs/:id` y `weekIndex` en sesiones de plan, con validación. (Prerequisito del Plan 1.)
- **Plataforma de creadores:** tarjeta "Planificaciones por nivel" en el shell del programa (mapea principiante/intermedio/avanzado → un plan existente) + selector "Semana del mes" (`weekIndex`) en el editor de sesión de plan.
- Helpers puros con tests + reuso de `programService.updateProgram` y del editor de planes.
- Todo **aditivo**: programas sin `level_plans`/`weekIndex` se comportan igual que hoy.

## Verificación
- functions: `tsc` build limpio; vitest (no-emulador) pasa.
- creator-dashboard: vitest 4/4; build limpio.
- **API runtime E2E (emulador):** PATCH persiste `levels`/`level_plans` y `weekIndex`; entradas inválidas → 400.
- **Browser GUI E2E (Playwright + emulador):** activar niveles → mapear 3 planes → guardar → persiste tras recargar; selector `weekIndex` funciona. El E2E **cazó y arreglamos** un bug del toggle (se revertía por un `initial` inestable).

## No incluido (follow-ups)
- Backend de resolución de lectura (nivel→plan→mes→semana) + `PATCH /users/me/courses/:id/level` + gating del cron (Plan 1, tareas 1–8).
- PWA: modal de nivel + etiqueta/dropdown en el Hoy card (Plan 3).
- Seed del contenido: shell ABS + 3 planes + año (Plan 4).

## Test plan
- [ ] Desplegar functions (staging/prod, con confirmación) para que el dashboard persista los campos nuevos.
- [ ] Abrir un programa general → "Planificaciones por nivel" → mapear 3 planes → guardar.
- [ ] Fijar `weekIndex` en una sesión de plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)